### PR TITLE
(chore) Create mono-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# 4-growth
+# 4-GROWTH
+
+This is a mono-repo project that contains several applications, all part of the 4-GROWTH initiative. The applications are built using a variety of technologies, including TypeScript, JavaScript, and React.
+
+## Applications
+
+The repository includes the following applications:
+
+- `api`: This is the backend application, built with NestJS.
+- `client`: This is the frontend application, built with React.
+
+TODO: Add the following applications to the list:
+- `admin`: This is the admin panel
+
+## Package Manager
+
+We use `pnpm` for managing packages in this project. This allows us to efficiently share common dependencies across the different applications in the mono-repo.
+
+## Mono-repo Architecture
+
+The mono-repo architecture allows us to keep all our related applications in one place, making it easier to share code and manage dependencies. Each application resides in its own directory and has its own `package.json` file.
+
+## Scripts
+
+Here are some of the npm scripts that you can run:
+
+- `pnpm start:api`: Starts the backend application
+- `pnpm start:client`: Starts the application in watch mode
+- `pnpm install`: Install all dependencies

--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,29 @@
-4-GROWTH API
+# 4-GROWTH API
+
+This project is built with NestJS.
+
+## NestJS Version
+
+The project uses NestJS version 10.0.0.
+
+## Package Manager
+
+The project uses `pnpm` as the package manager.
+
+## Node Version
+
+The project uses Node.js version 20.10.0 as specified in the `.nvmrc` file.
+
+## Continuous Integration
+
+The project uses GitHub Actions for continuous integration. The workflow for API tests is defined in `.github/workflows/api-tests.yml`. This workflow runs end-to-end tests on every push to the `api` directory and can also be manually triggered.
+
+## Scripts
+
+Here are some of the npm scripts that you can run:
+
+- `pnpm build`: Compiles the TypeScript code
+- `pnpm start`: Starts the application
+- `pnpm start:dev`: Starts the application in watch mode
+- `pnpm test`: Runs the tests
+- `pnpm test:e2e`: Runs the end-to-end tests

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api",
+  "name": "4-growth-api",
   "version": "0.0.1",
   "description": "",
   "author": "",

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "4-growth",
+  "name": "4-growth-client",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-packages:
-  # include packages in subfolders (e.g. apps/ and packages/)
-  - "apps/**"
-  - 'packages/**'
-  # if required, exclude some directories
-  - '!**/test/**'

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,6 +1,12 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "baseUrl": ".",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +24,16 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "4-growth",
+  "private": true,
+  "scripts": {
+    "install": "pnpm install",
+    "start:api": "pnpm --filter 4-growth-api run start",
+    "start:client": "pnpm --filter 4-growth-client run dev"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/pnpm-workspaces.yaml
+++ b/pnpm-workspaces.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'api/**'
+  - 'client/**'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@api/*": ["./api/src/*"],
+      "@client/*": ["./client/web/*"]
+    }
+  }
+}


### PR DESCRIPTION
This PR architectures the project as a mono-repo, leveraging pnpm workspaces.

It adds a base tsconfig in the root, with paths to both api and client, and a common package.json to run the apps

