### PR TITLE
(chore) Update data model: Add custom charts

### DIFF
--- a/api/src/typeorm.config.ts
+++ b/api/src/typeorm.config.ts
@@ -1,8 +1,6 @@
 import { DataSourceOptions } from 'typeorm';
 import { AppConfig } from '@api/utils/app-config';
-import { User } from '@shared/dto/users/user.entity';
-import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
-import { ChartFilter } from '@shared/dto/custom-charts/custom-chart-filter.entity';
+import { DB_ENTITIES } from '@shared/lib/db-entities';
 
 /**
  * TypeORM configuration.
@@ -17,6 +15,6 @@ export const typeOrmConfig: DataSourceOptions = {
   username: dbConfig.username,
   password: dbConfig.password,
   database: dbConfig.database,
-  entities: [User, CustomChart, ChartFilter],
+  entities: DB_ENTITIES,
   synchronize: true,
 };

--- a/api/src/typeorm.config.ts
+++ b/api/src/typeorm.config.ts
@@ -1,6 +1,8 @@
 import { DataSourceOptions } from 'typeorm';
 import { AppConfig } from '@api/utils/app-config';
 import { User } from '@shared/dto/users/user.entity';
+import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
+import { ChartFilter } from '@shared/dto/custom-charts/custom-chart-filter.entity';
 
 /**
  * TypeORM configuration.
@@ -15,6 +17,6 @@ export const typeOrmConfig: DataSourceOptions = {
   username: dbConfig.username,
   password: dbConfig.password,
   database: dbConfig.database,
-  entities: [User],
+  entities: [User, CustomChart, ChartFilter],
   synchronize: true,
 };

--- a/shared/dto/custom-charts/custom-chart-filter.entity.ts
+++ b/shared/dto/custom-charts/custom-chart-filter.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
+import { JoinColumn } from 'typeorm';
+
+export enum CHART_FILTER_ATTRIBUTES {
+  COUNTRY = 'country',
+  OPERATIONAL_AREAS = 'operational_areas',
+  TECHNOLOGY_TYPES = 'technology_types',
+}
+
+@Entity({ name: 'chart_filters' })
+export class ChartFilter {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: CHART_FILTER_ATTRIBUTES })
+  attribute: CHART_FILTER_ATTRIBUTES;
+
+  @Column({ type: 'varchar' })
+  value: string;
+
+  @ManyToOne(() => CustomChart, (customChart) => customChart.chartFilters)
+  @JoinColumn({ name: 'custom_chart_id' })
+  customChart: CustomChart;
+}

--- a/shared/dto/custom-charts/custom-chart.entity.ts
+++ b/shared/dto/custom-charts/custom-chart.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '@shared/dto/users/user.entity';
+import { ChartFilter } from '@shared/dto/custom-charts/custom-chart-filter.entity';
+
+export enum CUSTOM_CHART_TYPE {
+  MAP = 'map',
+  BAR = 'bar',
+  DOUGHNUT = 'doughnut',
+  STACKED_BAR = 'stacked_bar',
+}
+
+// TODO: We don't really know if this will be a enum, a table, or where to get the values from
+
+export enum INDICATORS {
+  DIGITAL_TECHNOLOGIES = 'digital_technologies',
+  GOALS_OR_CHALLENGES = 'goals_or_challenges',
+}
+
+@Entity({ name: 'custom_charts' })
+export class CustomChart {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  name: string;
+
+  @Column({
+    type: 'enum',
+    enum: CUSTOM_CHART_TYPE,
+    default: CUSTOM_CHART_TYPE.BAR,
+  })
+  type: CUSTOM_CHART_TYPE;
+
+  @Column({ type: 'enum', enum: INDICATORS })
+  indicator: INDICATORS;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @ManyToOne(() => User, (user) => user.customCharts)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @OneToMany(() => ChartFilter, (chartFilter) => chartFilter.customChart)
+  chartFilters: ChartFilter[];
+}

--- a/shared/dto/users/user.entity.ts
+++ b/shared/dto/users/user.entity.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
+import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
 
 @Entity({ name: 'users' })
 export class User {
@@ -20,4 +22,7 @@ export class User {
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @OneToMany(() => CustomChart, (customChart) => customChart.user)
+  customCharts: CustomChart[];
 }

--- a/shared/lib/db-entities.ts
+++ b/shared/lib/db-entities.ts
@@ -1,0 +1,11 @@
+import { MixedList } from 'typeorm/common/MixedList';
+import { EntitySchema } from 'typeorm/entity-schema/EntitySchema';
+import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
+import { User } from '@shared/dto/users/user.entity';
+import { ChartFilter } from '@shared/dto/custom-charts/custom-chart-filter.entity';
+
+export const DB_ENTITIES: MixedList<Function | string | EntitySchema> = [
+  User,
+  CustomChart,
+  ChartFilter,
+];

--- a/shared/lib/e2e-test-manager.ts
+++ b/shared/lib/e2e-test-manager.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import { User } from '@shared/dto/users/user.entity';
 import { createUser } from '@shared/lib/entity-mocks';
 import { clearTestDataFromDatabase } from '@shared/lib/db-helpers';
+import { DB_ENTITIES } from '@shared/lib/db-entities';
 
 const AppDataSource = new DataSource({
   type: 'postgres',
@@ -10,7 +11,7 @@ const AppDataSource = new DataSource({
   username: '4growth',
   password: '4growth',
   database: '4growth',
-  entities: [User],
+  entities: DB_ENTITIES,
 });
 
 export class E2eTestManager {


### PR DESCRIPTION

### Overview

This PR adds 2 new DB entities: Custom Charts and Chart Filters

The entities are defined in `shared/dto/custom-charts`

These are loaded into typeorm.config so that when the api is launched, the model is recreated in the DB.

Since this does not include any functionality and the purpose is to unblock other tasks, there are no tests, which will be added in next task when we actually retrieve stuff using this new tables

