### PR TITLE
(chore) SIRH-94 create api events

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { JwtAuthGuard } from '@api/guards/jwt-auth.guard';
 import { TsRestModule } from '@ts-rest/nest';
 import { EmailModule } from './modules/email/email.module';
 import { ContactMailer } from '@api/contact.mailer';
+import { ApiEventsModule } from '@api/modules/api-events/api-events.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { ContactMailer } from '@api/contact.mailer';
     UsersModule,
     AuthModule,
     EmailModule,
+    ApiEventsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/api/src/modules/api-events/api-events.module.ts
+++ b/api/src/modules/api-events/api-events.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ApiEventEntity } from '@shared/dto/api-events/api-events.entity';
+import { ApiEventsService } from '@api/modules/api-events/api-events.service';
+
+@Global()
+@Module({
+  imports: [TypeOrmModule.forFeature([ApiEventEntity])],
+  providers: [ApiEventsService],
+  exports: [ApiEventsService],
+})
+export class ApiEventsModule {}

--- a/api/src/modules/api-events/api-events.service.ts
+++ b/api/src/modules/api-events/api-events.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ApiEventEntity } from '@shared/dto/api-events/api-events.entity';
+import { API_EVENT_TYPES } from '@shared/dto/api-events/api-event.types';
+
+/**
+ * @description: At some point we might need to extend this to use events to decouple the event creation from the logic.
+ *               it might be useful to create custom decorators for methods to fire events instead of calling this service directly in each method.
+ *               this will also allow us to split event types but it will also increase complexity. i.e we could have a handler/service for each event group
+ */
+
+@Injectable()
+export class ApiEventsService {
+  public eventMap = {
+    USER_EVENTS: {
+      USER_SIGNED_UP: API_EVENT_TYPES.USER_SIGNED_UP,
+      USER_REQUESTED_PASSWORD_RECOVERY:
+        API_EVENT_TYPES.USER_REQUESTED_PASSWORD_RECOVERY,
+      USER_RECOVERED_PASSWORD: API_EVENT_TYPES.USER_RECOVERED_PASSWORD,
+      USER_NOT_FOUND_FOR_PASSWORD_RECOVERY:
+        API_EVENT_TYPES.USER_NOT_FOUND_FOR_PASSWORD_RECOVERY,
+    },
+  };
+  constructor(
+    @InjectRepository(ApiEventEntity)
+    readonly eventRepo: Repository<ApiEventEntity>,
+  ) {}
+
+  async saveEvent(event: ApiEventEntity): Promise<void> {
+    await this.eventRepo.insert(event);
+  }
+
+  async createEvent(
+    type: API_EVENT_TYPES,
+    payload: { associatedId?: string; data?: Record<string, unknown> },
+  ): Promise<void> {
+    const { associatedId, data } = payload;
+    const event = new ApiEventEntity();
+    event.type = type;
+    event.associatedId = associatedId;
+    event.data = data;
+    await this.saveEvent(event);
+  }
+}

--- a/api/src/modules/auth/password/password-recovery-email.service.ts
+++ b/api/src/modules/auth/password/password-recovery-email.service.ts
@@ -2,7 +2,7 @@ import {
   IEmailServiceInterface,
   IEmailServiceToken,
 } from '@api/modules/email/email.service.interface';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { AppConfig } from '@api/utils/app-config';
 
 export type PasswordRecovery = {
@@ -13,7 +13,6 @@ export type PasswordRecovery = {
 
 @Injectable()
 export class PasswordRecoveryEmailService {
-  logger: Logger = new Logger(PasswordRecoveryEmailService.name);
   constructor(
     @Inject(IEmailServiceToken)
     private readonly emailService: IEmailServiceInterface,
@@ -45,9 +44,6 @@ export class PasswordRecoveryEmailService {
       subject: 'Recover Password',
       html: htmlContent,
     });
-    this.logger.log(
-      `Password recovery email sent to ${passwordRecovery.email}`,
-    );
   }
 }
 

--- a/api/src/modules/users/users.service.ts
+++ b/api/src/modules/users/users.service.ts
@@ -11,6 +11,7 @@ import { CustomChartsService } from '@api/modules/custom-charts/custom-charts.se
 import { AuthService } from '@api/modules/auth/auth.service';
 import { UpdateUserPasswordDto } from '@shared/dto/users/update-user-password.dto';
 import { PasswordService } from '@api/modules/auth/password/password.service';
+import { ApiEventsService } from '@api/modules/api-events/api-events.service';
 
 @Injectable()
 export class UsersService extends AppBaseService<
@@ -24,8 +25,9 @@ export class UsersService extends AppBaseService<
     private readonly customChartService: CustomChartsService,
     private readonly authService: AuthService,
     private readonly passwordService: PasswordService,
+    private readonly events: ApiEventsService,
   ) {
-    super(userRepository, UsersService.name);
+    super(userRepository, 'user', 'users');
   }
 
   async createUser(createUserDto: CreateUserDto) {
@@ -59,6 +61,9 @@ export class UsersService extends AppBaseService<
   async resetPassword(user: User, newPassword: string) {
     user.password = await this.passwordService.hashPassword(newPassword);
     await this.userRepository.save(user);
-    this.logger.log(`User ${user.email} password has been reset`);
+    await this.events.createEvent(
+      this.events.eventMap.USER_EVENTS.USER_RECOVERED_PASSWORD,
+      { associatedId: user.id },
+    );
   }
 }

--- a/api/test/api-events/api-events.spec.ts
+++ b/api/test/api-events/api-events.spec.ts
@@ -1,0 +1,62 @@
+import { TestManager } from '../utils/test-manager';
+import { Repository } from 'typeorm';
+import { AuthService } from '@api/modules/auth/auth.service';
+import { ApiEventEntity } from '@shared/dto/api-events/api-events.entity';
+import { API_EVENT_TYPES } from '@shared/dto/api-events/api-event.types';
+import { UsersService } from '@api/modules/users/users.service';
+
+describe('Api Events', () => {
+  let testManager: TestManager<any>;
+  let authService: AuthService;
+  let usersService: UsersService;
+  let apiEventsRepository: Repository<ApiEventEntity>;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager();
+    authService = testManager.moduleFixture.get<AuthService>(AuthService);
+    usersService = testManager.moduleFixture.get<UsersService>(UsersService);
+    apiEventsRepository = testManager.dataSource.getRepository(ApiEventEntity);
+  });
+
+  afterEach(async () => {
+    await testManager.clearDatabase();
+  });
+  it('an api event should be registered if a user has requested password recovery but the provided email is not found in the system', async () => {
+    await authService.recoverPassword({ email: 'not-existing-user@test.com' });
+    const apiEvent = await apiEventsRepository.findOne({
+      where: { type: API_EVENT_TYPES.USER_NOT_FOUND_FOR_PASSWORD_RECOVERY },
+    });
+
+    expect(apiEvent).toBeDefined();
+    expect(apiEvent.data.email).toEqual('not-existing-user@test.com');
+  });
+  it('an api event should be registered if a user has requested password recovery successfully', async () => {
+    const user = await testManager
+      .mocks()
+      .createUser({ email: 'recovery@email.com' });
+    await authService.recoverPassword({ email: user.email });
+    const apiEvent = await apiEventsRepository.findOne({
+      where: { type: API_EVENT_TYPES.USER_REQUESTED_PASSWORD_RECOVERY },
+    });
+    expect(apiEvent).toBeDefined();
+    expect(apiEvent.associatedId).toEqual(user.id);
+  });
+  it('an api event should be registered when a user signs up', async () => {
+    await authService.signUp({ email: 'test@mail.com', password: '12345678' });
+    const apiEvent = await apiEventsRepository.findOne({
+      where: { type: API_EVENT_TYPES.USER_SIGNED_UP },
+    });
+    expect(apiEvent).toBeDefined();
+  });
+  it('an api event should be registered when a user recovers password', async () => {
+    const user = await testManager
+      .mocks()
+      .createUser({ email: 'test@test.com' });
+    await usersService.resetPassword(user, 'new-password');
+    const apiEvent = await apiEventsRepository.findOne({
+      where: { type: API_EVENT_TYPES.USER_RECOVERED_PASSWORD },
+    });
+    expect(apiEvent).toBeDefined();
+    expect(apiEvent.associatedId).toEqual(user.id);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6878,7 +6878,7 @@ snapshots:
       '@nestjs/core': 10.3.8(@nestjs/common@10.3.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.8)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
-      typeorm: 0.3.20(pg@8.11.5)(ts-node@10.9.2(typescript@5.4.5))
+      typeorm: 0.3.20(pg@8.11.5)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       uuid: 9.0.1
 
   '@next/env@14.2.3': {}
@@ -12082,6 +12082,29 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typedarray@0.0.6: {}
+
+  typeorm@0.3.20(pg@8.11.5)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      chalk: 4.1.2
+      cli-highlight: 2.1.11
+      dayjs: 1.11.11
+      debug: 4.3.4
+      dotenv: 16.4.5
+      glob: 10.3.16
+      mkdirp: 2.1.6
+      reflect-metadata: 0.2.2
+      sha.js: 2.4.11
+      tslib: 2.6.2
+      uuid: 9.0.1
+      yargs: 17.7.2
+    optionalDependencies:
+      pg: 8.11.5
+      ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - supports-color
 
   typeorm@0.3.20(pg@8.11.5)(ts-node@10.9.2(typescript@5.4.5)):
     dependencies:

--- a/shared/dto/api-events/api-event.types.ts
+++ b/shared/dto/api-events/api-event.types.ts
@@ -1,0 +1,8 @@
+// Types of events that will be stored in the database.
+
+export enum API_EVENT_TYPES {
+  USER_SIGNED_UP = 'user_signed-up',
+  USER_REQUESTED_PASSWORD_RECOVERY = 'user_requested-password-recovery',
+  USER_NOT_FOUND_FOR_PASSWORD_RECOVERY = 'user_not-found-for-password-recovery',
+  USER_RECOVERED_PASSWORD = 'user_recovered-password',
+}

--- a/shared/dto/api-events/api-events.entity.ts
+++ b/shared/dto/api-events/api-events.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { API_EVENT_TYPES } from '@shared/dto/api-events/api-event.types';
+
+// TODO: create appropriate indexes for generating views later on
+
+@Entity({ name: 'api_events' })
+export class ApiEventEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('timestamp', { default: () => 'now()' })
+  timestamp!: Date;
+
+  // Type of event, providing a brief description of the event.
+  @Column({ type: 'varchar', enum: API_EVENT_TYPES })
+  type!: API_EVENT_TYPES;
+
+  // Id of the resource associated with the event.
+  @Column({ type: 'uuid', nullable: true })
+  associatedId: string;
+
+  // Payload of the event
+  @Column({ type: 'jsonb', nullable: true })
+  data: Record<string, unknown>;
+}

--- a/shared/lib/db-entities.ts
+++ b/shared/lib/db-entities.ts
@@ -3,9 +3,11 @@ import { EntitySchema } from 'typeorm/entity-schema/EntitySchema';
 import { CustomChart } from '@shared/dto/custom-charts/custom-chart.entity';
 import { User } from '@shared/dto/users/user.entity';
 import { ChartFilter } from '@shared/dto/custom-charts/custom-chart-filter.entity';
+import { ApiEventEntity } from '@shared/dto/api-events/api-events.entity';
 
 export const DB_ENTITIES: MixedList<Function | string | EntitySchema> = [
   User,
   CustomChart,
   ChartFilter,
+  ApiEventEntity,
 ];


### PR DESCRIPTION
Introduces a historic registry for significant api events, that are registered in a api_events table in the database.

since currently we don't have a big amount of events, the system is coupled to a single service, but we can extend it to use a event based system to decouple different types of events for specific providers. I have considered an event based approach would introduce a complexity that is not needed and its not clear if we will ever need to.

Aditionaly, we could create views based on different types of events for easier check and maintenance

