### PR TITLE
(feat) SIRH-97 backlinck from vis tool page

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "zod": "3.23.8"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.4.5",
+    "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "^15.0.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20",
@@ -56,8 +56,10 @@
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "5.1.3",
+    "extend-expect": "link:@testing-library/jest-dom/extend-expect",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-mock": "29.7.0",
     "postcss": "^8",
     "prettier": "3.2.5",
     "prettier-plugin-tailwindcss": "0.6.5",

--- a/client/src/containers/auth/forgot-password/email-form/index.tsx
+++ b/client/src/containers/auth/forgot-password/email-form/index.tsx
@@ -52,6 +52,8 @@ const ForgotPasswordEmailForm: FC = () => {
             variant: "destructive",
             description: "Something went wrong",
           });
+        } finally {
+          form.reset();
         }
       })(evt);
     },

--- a/client/src/containers/header/menu/index.tsx
+++ b/client/src/containers/header/menu/index.tsx
@@ -13,7 +13,7 @@ const Menu: FC = () => {
     <nav className="min-w-[150px]">
       <ul className="overflow-hidden py-2">
         <li>
-          <Link
+          <a
             href="https://4growth-project.eu/"
             target="_blank"
             rel="noopener noreferrer"
@@ -21,7 +21,7 @@ const Menu: FC = () => {
             className={classes.link}
           >
             4Growth project site
-          </Link>
+          </a>
         </li>
         <li>
           <Link href="/about" className={classes.link}>

--- a/client/src/containers/header/menu/index.tsx
+++ b/client/src/containers/header/menu/index.tsx
@@ -13,6 +13,17 @@ const Menu: FC = () => {
     <nav className="min-w-[150px]">
       <ul className="overflow-hidden py-2">
         <li>
+          <Link
+            href="https://4growth-project.eu/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="4Growth project site"
+            className={classes.link}
+          >
+            4Growth project site
+          </Link>
+        </li>
+        <li>
           <Link href="/about" className={classes.link}>
             About
           </Link>

--- a/client/tests/contact-us-form.test.tsx
+++ b/client/tests/contact-us-form.test.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mocked } from "jest-mock";
 
-import "@testing-library/jest-dom/extend-expect";
 import { client } from "@/lib/queryClient";
 
 import ContactUsForm from "@/containers/contact-us";
@@ -64,7 +64,7 @@ describe("ContactUsForm", () => {
   });
 
   it("submits the form successfully when filled correctly", async () => {
-    client.contact.contact.mutation.mockResolvedValueOnce({});
+    mocked(client.contact.contact.mutation).mockResolvedValueOnce({} as never);
 
     render(<ContactUsForm />);
 
@@ -96,7 +96,7 @@ describe("ContactUsForm", () => {
   });
 
   it("shows an error toast when form submission fails", async () => {
-    client.contact.contact.mutation.mockRejectedValueOnce(
+    mocked(client.contact.contact.mutation).mockRejectedValueOnce(
       new Error("Submission failed"),
     );
 
@@ -133,7 +133,7 @@ describe("ContactUsForm", () => {
   });
 
   it("displays loading animation while sending", async () => {
-    client.contact.contact.mutation.mockImplementation(() => {
+    mocked(client.contact.contact.mutation).mockImplementation(() => {
       return new Promise((resolve) => setTimeout(resolve, 100));
     });
 

--- a/client/tests/forgot-password-email-form.test.tsx
+++ b/client/tests/forgot-password-email-form.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mocked } from "jest-mock";
 
 import { client } from "@/lib/queryClient";
 
@@ -45,9 +46,11 @@ describe("ForgotPasswordEmailForm", () => {
 
   it("calls apiResponseToast on successful response", async () => {
     const mockResponse = { status: 200 };
-    client.auth.recoverPassword.mutation.mockResolvedValue(mockResponse);
+    mocked(client.auth.recoverPassword.mutation).mockResolvedValue(
+      mockResponse as never,
+    );
     const mockApiResponseToast = jest.fn();
-    useApiResponseToast.mockReturnValue({
+    mocked(useApiResponseToast).mockReturnValue({
       apiResponseToast: mockApiResponseToast,
       toast: jest.fn(),
     });
@@ -67,11 +70,11 @@ describe("ForgotPasswordEmailForm", () => {
   });
 
   it("shows error toast on failed response", async () => {
-    client.auth.recoverPassword.mutation.mockRejectedValue(
+    mocked(client.auth.recoverPassword.mutation).mockRejectedValue(
       new Error("Network error"),
     );
     const mockToast = jest.fn();
-    useApiResponseToast.mockReturnValue({
+    mocked(useApiResponseToast).mockReturnValue({
       apiResponseToast: jest.fn(),
       toast: mockToast,
     });

--- a/client/tests/new-password-form.test.tsx
+++ b/client/tests/new-password-form.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useRouter, useParams } from "next/navigation";
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
+import { mocked } from "jest-mock";
 
 import { client } from "@/lib/queryClient";
 
@@ -36,13 +36,13 @@ describe("NewPasswordForm", () => {
   const mockToast = jest.fn();
 
   beforeEach(() => {
-    useRouter.mockReturnValue({ push: mockPush });
-    useParams.mockReturnValue({ token: "mockToken" });
-    useApiResponseToast.mockReturnValue({
+    mocked(useRouter).mockReturnValue({ push: mockPush } as never);
+    mocked(useParams).mockReturnValue({ token: "mockToken" });
+    mocked(useApiResponseToast).mockReturnValue({
       apiResponseToast: mockApiResponseToast,
       toast: mockToast,
     });
-    client.user.resetPassword.mutation.mockClear();
+    mocked(client.user.resetPassword.mutation).mockClear();
     mockPush.mockClear();
     mockApiResponseToast.mockClear();
     mockToast.mockClear();
@@ -92,7 +92,9 @@ describe("NewPasswordForm", () => {
   });
 
   it("submits form successfully with matching passwords", async () => {
-    client.user.resetPassword.mutation.mockResolvedValueOnce({ status: 200 });
+    mocked(client.user.resetPassword.mutation).mockResolvedValueOnce({
+      status: 200,
+    } as never);
 
     render(<NewPasswordForm />);
 
@@ -120,7 +122,7 @@ describe("NewPasswordForm", () => {
   });
 
   it("shows an error toast when submission fails", async () => {
-    client.user.resetPassword.mutation.mockRejectedValueOnce(
+    mocked(client.user.resetPassword.mutation).mockRejectedValueOnce(
       new Error("Error"),
     );
 

--- a/client/tests/use-api-response-toas-with-component.test.tsx
+++ b/client/tests/use-api-response-toas-with-component.test.tsx
@@ -1,19 +1,20 @@
 import React from "react";
 
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mocked } from "jest-mock";
 
-import "@testing-library/jest-dom/extend-expect";
+// eslint-disable-next-line import/order
 import { useApiResponseToast } from "@/components/ui/use-api-response-toast";
 
 /**
  * @description: We create a mock test wrapper for the component since react-hooks package for testing library throws several deprecation warnings.
  */
 
-const TestComponent = ({ response, options }) => {
+const TestComponent = (props: { response: never; options: never }) => {
   const { apiResponseToast } = useApiResponseToast();
 
   return (
-    <button onClick={() => apiResponseToast(response, options)}>
+    <button onClick={() => apiResponseToast(props.response, props.options)}>
       Trigger Toast
     </button>
   );
@@ -30,13 +31,15 @@ describe("useApiResponseToast", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    useToast.mockReturnValue({ toast: mockToast });
+    mocked(useToast).mockReturnValue({ toast: mockToast } as never);
   });
 
   it("shows a success toast for 2xx response", async () => {
     const response = { status: 200 };
     const options = { successMessage: "Success!" };
-    render(<TestComponent response={response} options={options} />);
+    render(
+      <TestComponent response={response as never} options={options as never} />,
+    );
 
     fireEvent.click(screen.getByText("Trigger Toast"));
 
@@ -53,7 +56,9 @@ describe("useApiResponseToast", () => {
       successMessage: "Success!",
       customErrorMessage: "Custom error message",
     };
-    render(<TestComponent response={response} options={options} />);
+    render(
+      <TestComponent response={response as never} options={options as never} />,
+    );
 
     fireEvent.click(screen.getByText("Trigger Toast"));
 
@@ -69,8 +74,8 @@ describe("useApiResponseToast", () => {
     const response = {
       status: 400,
       body: { errors: [{ title: "Error 1" }, { title: "Error 2" }] },
-    };
-    const options = { successMessage: "Success!" };
+    } as never;
+    const options = { successMessage: "Success!" } as never;
     render(<TestComponent response={response} options={options} />);
 
     fireEvent.click(screen.getByText("Trigger Toast"));
@@ -86,8 +91,8 @@ describe("useApiResponseToast", () => {
   });
 
   it("shows a default error toast for 5xx response", async () => {
-    const response = { status: 500 };
-    const options = { successMessage: "Success!" };
+    const response = { status: 500 } as never;
+    const options = { successMessage: "Success!" } as never;
     render(<TestComponent response={response} options={options} />);
 
     fireEvent.click(screen.getByText("Trigger Toast"));

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,6 +6,11 @@
       "dom.iterable",
       "esnext"
     ],
+    "types": [
+      "node",
+      "jest",
+      "@testing-library/jest-dom"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         version: 3.23.8
     devDependencies:
       '@testing-library/jest-dom':
-        specifier: ^5.4.5
-        version: 5.17.0
+        specifier: 6.4.8
+        version: 6.4.8
       '@testing-library/react':
         specifier: ^15.0.7
         version: 15.0.7(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -291,11 +291,17 @@ importers:
       eslint-plugin-prettier:
         specifier: 5.1.3
         version: 5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.2.5)
+      extend-expect:
+        specifier: link:@testing-library/jest-dom/extend-expect
+        version: link:@testing-library/jest-dom/extend-expect
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.12.12)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
       jest-environment-jsdom:
         specifier: ^29.7.0
+        version: 29.7.0
+      jest-mock:
+        specifier: 29.7.0
         version: 29.7.0
       postcss:
         specifier: ^8
@@ -404,8 +410,8 @@ importers:
 
 packages:
 
-  '@adobe/css-tools@4.3.3':
-    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
+  '@adobe/css-tools@4.4.0':
+    resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1907,9 +1913,9 @@ packages:
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
     engines: {node: '>=18'}
 
-  '@testing-library/jest-dom@5.17.0':
-    resolution: {integrity: sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==}
-    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
+  '@testing-library/jest-dom@6.4.8':
+    resolution: {integrity: sha512-JD0G+Zc38f5MBHA4NgxQMR5XtO5Jx9g86jqturNTt2WUfRmLDIY7iKkWHDCCTiDuFMre6nxAD5wHw9W5kI4rGw==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/react@15.0.7':
     resolution: {integrity: sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==}
@@ -2107,9 +2113,6 @@ packages:
 
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
-
-  '@types/testing-library__jest-dom@5.14.9':
-    resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -3017,6 +3020,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -5836,7 +5842,7 @@ packages:
 
 snapshots:
 
-  '@adobe/css-tools@4.3.3': {}
+  '@adobe/css-tools@4.4.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -6878,7 +6884,7 @@ snapshots:
       '@nestjs/core': 10.3.8(@nestjs/common@10.3.8(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.8)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
-      typeorm: 0.3.20(pg@8.11.5)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))
+      typeorm: 0.3.20(pg@8.11.5)(ts-node@10.9.2(typescript@5.4.5))
       uuid: 9.0.1
 
   '@next/env@14.2.3': {}
@@ -7828,15 +7834,14 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@5.17.0':
+  '@testing-library/jest-dom@6.4.8':
     dependencies:
-      '@adobe/css-tools': 4.3.3
+      '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.24.5
-      '@types/testing-library__jest-dom': 5.14.9
       aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
-      dom-accessibility-api: 0.5.16
+      dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
 
@@ -8062,10 +8067,6 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.7
-
-  '@types/testing-library__jest-dom@5.14.9':
-    dependencies:
-      '@types/jest': 29.5.12
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -9109,6 +9110,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   domexception@4.0.0:
     dependencies:
@@ -12082,29 +12085,6 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typedarray@0.0.6: {}
-
-  typeorm@0.3.20(pg@8.11.5)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5)):
-    dependencies:
-      '@sqltools/formatter': 1.2.5
-      app-root-path: 3.1.0
-      buffer: 6.0.3
-      chalk: 4.1.2
-      cli-highlight: 2.1.11
-      dayjs: 1.11.11
-      debug: 4.3.4
-      dotenv: 16.4.5
-      glob: 10.3.16
-      mkdirp: 2.1.6
-      reflect-metadata: 0.2.2
-      sha.js: 2.4.11
-      tslib: 2.6.2
-      uuid: 9.0.1
-      yargs: 17.7.2
-    optionalDependencies:
-      pg: 8.11.5
-      ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - supports-color
 
   typeorm@0.3.20(pg@8.11.5)(ts-node@10.9.2(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
This PR adds a backlink in the menu component to the main 4-growth project web


**BUT MORE IMPORTANTLY:**

It attempts to fix the lack of typing in client component tests.

We could use several approaches, Ive decided to go with the one that I think its the best, but I am happy to discuss it before pushing this.

The decided approach:

1. Fixes lack of typing in global jest's `expect` by adding a global import in the setup before env file which is loaded by the jest config, and adding types in clients ts compiler options.

2. Fixes the lack of typing for mocked library/functions/whatever by wrapping them with jest-mock's `mocked` function.
    Still, mocking the whole file by jest is required.
    
    Since now the type inheritance is working, there is a need to cast mock responses to mocked libraries and functions, but this is fairly normal, and a price I am willing to pay

