### PR TITLE
(chore) Fix linting errors and add linting step in CI workflow

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -44,6 +44,10 @@ jobs:
         working-directory: api
         run: pnpm install
 
+      - name: Lint code
+        working-directory: api
+        run: pnpm lint
+
       - name: Run API E2E tests
         working-directory: api
         run: pnpm test:e2e

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,7 @@
     "start:prod": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint \"src/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/api/src/guards/jwt-auth.guard.ts
+++ b/api/src/guards/jwt-auth.guard.ts
@@ -29,7 +29,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     return super.canActivate(context);
   }
 
-  handleRequest(err, user, info) {
+  handleRequest(err, user) {
     if (err || !user) {
       throw err || new UnauthorizedException();
     }

--- a/api/src/modules/email/email.module.ts
+++ b/api/src/modules/email/email.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { IEmailServiceToken } from '@api/modules/email/email.service.interface';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { EmailProviderFactory } from '@api/modules/email/email.provider';
 
 @Module({


### PR DESCRIPTION
### Overview

This PR fixes some linting errors present in the codebase that were not compliant with the set standards.

I have ignored linting tests since code styles are applied by the IDE and we might need to break some rules for preconditions etc.

I have also added an extra linting step to API tests, since the client side already runs linting when building the client app, and even tho it would be more verbose to add it, it would still be a redundancy

Let me know ur thoughts

### Testing instructions

Run linting, it should be no errors. Check that linting is run as part of the CI workflow


