### PR TITLE
Entity query validator

### DIFF
--- a/api/test/users/custom-widgets/custom-widget-crud.spec.ts
+++ b/api/test/users/custom-widgets/custom-widget-crud.spec.ts
@@ -198,7 +198,7 @@ describe('Custom Widgets API', () => {
     });
 
     // TODO: Skipping this tests as filtering capabilities are not working, pending to fix the corresponding schema
-    it.skip('Should allow authenticated users to read their custom widgets using filters', async () => {
+    it('Should allow authenticated users to read their custom widgets using filters', async () => {
       // Given
       const customWidget1 = await entityMocks.createCustomWidget({
         name: 'custom-widget1',
@@ -224,7 +224,9 @@ describe('Custom Widgets API', () => {
       // When
       const res = await testManager
         .request()
-        .get(`/users/${testUser.id}/widgets?filter[name]=${customWidget1.name}`)
+        .get(
+          `/users/${testUser.id}/widgets?filter[name]=${customWidget1.name}&include[]=widget`,
+        )
         .set('Authorization', `Bearer ${authToken}`);
 
       // Then
@@ -232,6 +234,7 @@ describe('Custom Widgets API', () => {
       const responseData = res.body.data;
       expect(responseData).toHaveLength(1);
       expect(responseData[0].name).toBe(customWidget1.name);
+      expect(responseData[0].widget.id).toBe(baseWidget.id);
     });
 
     it("Shouldn't allow authenticated users to read other user's custom widgets", async () => {

--- a/client/src/containers/profile/saved-visualizations/table/index.tsx
+++ b/client/src/containers/profile/saved-visualizations/table/index.tsx
@@ -37,6 +37,8 @@ import { getAuthHeader } from "@/utils/auth-header";
 import { selectedRowAtom } from "../../store";
 
 import useColumns from "./columns";
+import { SortQueryParam } from "@shared/schemas/query-param.schema";
+import { CustomWidget } from "@shared/dto/widgets/custom-widget.entity";
 
 const ROWS_PER_PAGE_OPTIONS = ["10", "25", "50", "100"];
 
@@ -73,7 +75,9 @@ const SavedVisualizationsTable: FC = () => {
           "updatedAt",
         ],
         sort: Object.keys(sorting).length
-          ? sorting.map((sort) => `${sort.desc ? "" : "-"}${sort.id}`)
+          ? (sorting.map(
+              (sort) => `${sort.desc ? "" : "-"}${sort.id}`,
+            ) as SortQueryParam<CustomWidget>)
           : ["-updatedAt"],
         pageSize: pagination.size,
         pageNumber: pagination.page,

--- a/shared/contracts/sections.contract.ts
+++ b/shared/contracts/sections.contract.ts
@@ -1,15 +1,15 @@
 import { JSONAPIError } from '@shared/dto/errors/json-api.error';
 import { ApiPaginationResponse } from '@shared/dto/global/api-response.dto';
 import { Section } from '@shared/dto/sections/section.entity';
+import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
 import { initContract } from '@ts-rest/core';
-import { FetchSpecificationSchema } from '@shared/schemas/query-param.schema';
 
 const contract = initContract();
 export const sectionContract = contract.router({
   searchSections: {
     method: 'GET',
     path: '/sections',
-    query: FetchSpecificationSchema,
+    query: generateEntityQuerySchema(Section),
     responses: {
       200: contract.type<ApiPaginationResponse<Section>>(),
       400: contract.type<JSONAPIError>(),

--- a/shared/contracts/users.contract.ts
+++ b/shared/contracts/users.contract.ts
@@ -15,7 +15,8 @@ import {
   CreateCustomWidgetSchema,
   UpdateCustomWidgetSchema,
 } from '@shared/schemas/widget.schemas';
-import { FetchSpecificationSchema } from '@shared/schemas/query-param.schema';
+import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
+import { User } from '@shared/dto/users/user.entity';
 
 const contract = initContract();
 export const usersContract = contract.router({
@@ -37,7 +38,7 @@ export const usersContract = contract.router({
       400: contract.type<{ message: string }>(),
     },
     summary: 'Get all users',
-    query: FetchSpecificationSchema,
+    query: generateEntityQuerySchema(User),
   },
   findMe: {
     method: 'GET',
@@ -46,7 +47,7 @@ export const usersContract = contract.router({
       200: contract.type<ApiResponse<UserDto>>(),
       401: contract.type<JSONAPIError>(),
     },
-    query: FetchSpecificationSchema,
+    query: generateEntityQuerySchema(User),
   },
   updatePassword: {
     method: 'PATCH',
@@ -70,7 +71,7 @@ export const usersContract = contract.router({
       400: contract.type<JSONAPIError>(),
       401: contract.type<JSONAPIError>(),
     },
-    query: FetchSpecificationSchema,
+    query: generateEntityQuerySchema(User),
     summary: 'Get a user by id',
   },
   updateUser: {
@@ -111,7 +112,7 @@ export const usersContract = contract.router({
     method: 'GET',
     path: '/users/:userId/widgets',
     pathParams: z.object({ userId: z.string().uuid() }),
-    query: FetchSpecificationSchema,
+    query: generateEntityQuerySchema(CustomWidget),
     responses: {
       200: contract.type<ApiPaginationResponse<CustomWidget>>(),
       400: contract.type<JSONAPIError>(),

--- a/shared/schemas/query-param.schema.ts
+++ b/shared/schemas/query-param.schema.ts
@@ -40,9 +40,9 @@ const generateQuerySchema = <
   const sort = z.array(z.enum(config.sort as [SORT, ...SORT[]])).optional();
 
   return z.object({
-    pageSize: z.number().optional(),
-    pageNumber: z.number().optional(),
-    disablePagination: z.boolean().optional(),
+    pageSize: z.coerce.number().optional(),
+    pageNumber: z.coerce.number().optional(),
+    disablePagination: z.coerce.boolean().optional(),
     fields,
     omitFields,
     include,

--- a/shared/schemas/query-param.schema.ts
+++ b/shared/schemas/query-param.schema.ts
@@ -1,12 +1,127 @@
 import { z } from 'zod';
+import { getMetadataArgsStorage } from 'typeorm';
 
-export const FetchSpecificationSchema = z.object({
-  pageSize: z.coerce.number().optional(),
-  pageNumber: z.coerce.number().optional(),
-  disablePagination: z.coerce.boolean().optional(),
-  fields: z.array(z.string()).optional(),
-  omitFields: z.array(z.string()).optional(),
-  include: z.array(z.string()).optional(),
-  sort: z.array(z.string()).optional(),
-  filter: z.record(z.unknown()).optional(),
-});
+const generateQuerySchema = <
+  FIELDS extends string,
+  INCLUDES extends string,
+  FILTERS extends string,
+  OMIT_FIELDS extends string,
+  SORT extends string,
+>(config: {
+  fields?: readonly FIELDS[];
+  includes?: readonly INCLUDES[];
+  filter?: readonly FILTERS[];
+  omitFields?: readonly OMIT_FIELDS[];
+  sort?: readonly SORT[];
+}) => {
+  const fields = z
+    .array(z.enum(config.fields as [FIELDS, ...FIELDS[]]))
+    .optional();
+  const filter = z
+    .record(
+      z.enum(config.filter as [FILTERS, ...FILTERS[]]),
+      z.union([
+        z.string().transform((value) => {
+          return value.split(',');
+        }),
+        z.array(z.string()),
+      ]),
+    )
+    .optional();
+
+  const omitFields = z
+    .array(z.enum(config.omitFields as [OMIT_FIELDS, ...OMIT_FIELDS[]]))
+    .optional();
+
+  const include = z
+    .array(z.enum(config.includes as [INCLUDES, ...INCLUDES[]]))
+    .optional();
+
+  const sort = z.array(z.enum(config.sort as [SORT, ...SORT[]])).optional();
+
+  return z.object({
+    pageSize: z.number().optional(),
+    pageNumber: z.number().optional(),
+    disablePagination: z.boolean().optional(),
+    fields,
+    omitFields,
+    include,
+    sort,
+    filter,
+  });
+};
+
+type PropertyKeys<T> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [K in keyof T]: T[K] extends Function ? never : K;
+}[keyof T & string];
+
+type ExtractProperties<T> = Pick<T, PropertyKeys<T>>;
+
+type IsEntity<T> = unknown extends T // Exclude `any`
+  ? never
+  : T extends Date // Exclude `Date`
+  ? never
+  : T extends Array<infer U> // If `T` is an array, check the type of the elements
+  ? IsEntity<U> extends never // If the elements are not entities, exclude the array
+    ? never
+    : T // Include the array if the elements are valid entities
+  : T extends object // Check object types (non-arrays)
+  ? T extends { constructor: Function }
+    ? T // Include the object if it's a TypeORM entity
+    : never
+  : never;
+
+// Utility type to extract only relationship keys (those referencing other entities that extend BaseWidget)
+type RelationshipKeys<T> = {
+  [K in keyof T]: IsEntity<T[K]> extends never ? never : K;
+}[keyof T & string];
+
+// Extract only relationships from a class that extend BaseWidget
+type ExtractRelationships<T> = Pick<T, RelationshipKeys<T>>;
+
+export type FieldsQueryParam<T> = Array<keyof ExtractProperties<T>>;
+export type IncludesQueryParam<T> = Array<keyof ExtractRelationships<T>>;
+export type FilterQueryParam<T> = Array<keyof ExtractProperties<T>>;
+export type OmitFieldsQueryParam<T> = Array<keyof ExtractProperties<T>>;
+export type SortQueryParam<T> = Array<
+  keyof ExtractProperties<T> | `-${keyof ExtractProperties<T>}`
+>;
+
+export function generateEntityQuerySchema<T extends object>(
+  entityClass: {
+    new (): T;
+  },
+  config: {
+    fields?: FieldsQueryParam<T>;
+    includes?: IncludesQueryParam<T>;
+    filter?: FilterQueryParam<T>;
+    omitFields?: OmitFieldsQueryParam<T>;
+    sort?: SortQueryParam<T>;
+  } = {},
+) {
+  const metadata = getMetadataArgsStorage();
+  const properties = metadata.columns
+    .filter((t) => t.target === entityClass)
+    .map((e) => e.propertyName) as Array<keyof ExtractProperties<T>>;
+
+  const mergedEntityConfig = {
+    fields: config.fields ?? properties,
+    includes:
+      config.includes ??
+      (metadata.relations
+        .filter((relation) => relation.target === entityClass)
+        .map((relation) => relation.propertyName) as Array<
+        keyof ExtractRelationships<T>
+      >),
+    filter: config.filter ?? properties,
+    omitFields: config.omitFields,
+    sort:
+      config.sort ??
+      ([...properties, ...properties.map((p) => `-${p}`)] as Array<
+        keyof ExtractProperties<T> | `-${keyof ExtractProperties<T>}`
+      >),
+  } as const;
+
+  return generateQuerySchema(mergedEntityConfig);
+}


### PR DESCRIPTION
- refactor(front): Add type assertion on the frontend for dynamically generated QueryParams (SortQueryParam<CustomWidget>)
- refactor: Remove old FetchSpecificationSchema from requests that fetch data and replace it in favour of generateEntityQuerySchema
- test(api): Activate disabled test for custom-widget
-  feat: Add generateEntityQuerySchema in order to generate queryParams validation for contracts

