### PR TITLE
(chore) add mock data to base widgets

### DIFF
--- a/api/src/modules/sections/sections.controller.ts
+++ b/api/src/modules/sections/sections.controller.ts
@@ -13,8 +13,47 @@ export class SectionsController {
   @TsRestHandler(c.searchSections)
   public async searchSections(): Promise<ControllerResponse> {
     return tsRestHandler(c.searchSections, async ({ query }) => {
-      const data = await this.sectionsService.findAllPaginated(query);
-      return { body: data, status: 200 };
+      const { data, metadata } =
+        await this.sectionsService.findAllPaginated(query);
+      const mockedData = addRandomDataToWidgets(data);
+      return { body: { data: mockedData, metadata }, status: 200 };
     });
   }
+}
+
+/**
+ * @description temporal hack to add random data to widgets until we get access to the real data, or progress with filters
+ */
+
+function addRandomDataToWidgets(sections) {
+  const randomInt = (min, max) =>
+    Math.floor(Math.random() * (max - min + 1)) + min;
+
+  const randomLabel = () => {
+    const labels = [
+      'Value 1',
+      'Value 2',
+      'Value 3',
+      'Value 4',
+      'Value 5',
+      null,
+    ];
+    return labels[randomInt(0, labels.length - 1)];
+  };
+
+  const generateRandomDataObject = () => ({
+    value: randomInt(1, 1000),
+    total: randomInt(1000, 5000),
+    label: randomLabel(),
+  });
+
+  sections.forEach((section) => {
+    section.baseWidgets.forEach((widget) => {
+      const dataCount = randomInt(2, 5);
+
+      widget.data = Array.from({ length: dataCount }, generateRandomDataObject);
+    });
+  });
+
+  return sections;
 }

--- a/shared/contracts/sections.contract.ts
+++ b/shared/contracts/sections.contract.ts
@@ -1,6 +1,9 @@
 import { JSONAPIError } from '@shared/dto/errors/json-api.error';
 import { ApiPaginationResponse } from '@shared/dto/global/api-response.dto';
-import { Section } from '@shared/dto/sections/section.entity';
+import {
+  Section,
+  SectionWithDataWidget,
+} from '@shared/dto/sections/section.entity';
 import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
 import { initContract } from '@ts-rest/core';
 
@@ -9,7 +12,7 @@ export const sectionContract = contract.router({
   searchSections: {
     method: 'GET',
     path: '/sections',
-    query: generateEntityQuerySchema(Section),
+    query: generateEntityQuerySchema(SectionWithDataWidget),
     responses: {
       200: contract.type<ApiPaginationResponse<Section>>(),
       400: contract.type<JSONAPIError>(),

--- a/shared/dto/sections/section.entity.ts
+++ b/shared/dto/sections/section.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn,
   PrimaryColumn,
 } from 'typeorm';
+import { BaseWidgetWithData } from '@shared/dto/widgets/base-widget-data.interface';
 
 @Entity('sections')
 export class Section {
@@ -28,4 +29,8 @@ export class Section {
     onDelete: 'CASCADE',
   })
   baseWidgets: BaseWidget[];
+}
+
+export class SectionWithDataWidget extends Section {
+  baseWidgets: BaseWidgetWithData[];
 }

--- a/shared/dto/sections/section.entity.ts
+++ b/shared/dto/sections/section.entity.ts
@@ -32,5 +32,5 @@ export class Section {
 }
 
 export class SectionWithDataWidget extends Section {
-  baseWidgets: BaseWidgetWithData[];
+  declare baseWidgets: BaseWidgetWithData[];
 }

--- a/shared/dto/widgets/base-widget-data.interface.ts
+++ b/shared/dto/widgets/base-widget-data.interface.ts
@@ -1,12 +1,9 @@
+import { BaseWidget } from '@shared/dto/widgets/base-widget.entity';
+
 /**
  * Represents an array of widget data objects.
  */
 export type WidgetData = Array<{
-  /**
-   * Unique identifier
-   */
-  id: number;
-
   /** The numeric value associated with the widget answer, with or without applied filters */
   value: number;
 
@@ -19,3 +16,7 @@ export type WidgetData = Array<{
    */
   label: string | null;
 }>;
+
+export class BaseWidgetWithData extends BaseWidget {
+  data: WidgetData;
+}


### PR DESCRIPTION

This PR adds random mock data for each base widget for each sections based on the WidgetData interface.

It also overrides the contract specification for sections and widgets, adding an extra data property, which won't exists for the Database, but it will for the api consumer.

Lemme know your thoughts

