### PR TITLE
Test seed database

### DIFF
--- a/api/data/sections-csv-parser.ts
+++ b/api/data/sections-csv-parser.ts
@@ -22,7 +22,7 @@ const parseSectionsFromFile = async (
       csvParser.read();
 
       let currentWidgetIdx = 0;
-      let currentSectionOrder = 1;
+      let currentSectionOrder = 0;
       let currentWidgetSectionOrder = 0;
       let row: any;
       while ((row = csvParser.read()) != null) {

--- a/api/src/infrastructure/data-source-manager.ts
+++ b/api/src/infrastructure/data-source-manager.ts
@@ -10,9 +10,7 @@ export class DataSourceManager {
   public constructor(
     private readonly logger: Logger,
     @InjectDataSource() private readonly dataSource: DataSource,
-  ) {
-    this.logger = new Logger(this.constructor.name);
-  }
+  ) {}
 
   public async loadInitialData(): Promise<void> {
     const schemafilePath = `data/schema.sql`;

--- a/api/src/modules/auth/auth.module.ts
+++ b/api/src/modules/auth/auth.module.ts
@@ -10,13 +10,11 @@ import { JwtStrategy } from '@api/modules/auth/strategies/jwt.strategy';
 import { LocalStrategy } from '@api/modules/auth/strategies/local.strategy';
 import { PasswordRecoveryEmailService } from '@api/modules/auth/password/password-recovery-email.service';
 import { EmailModule } from '@api/modules/email/email.module';
-import { LoggingModule } from '@api/modules/logging/logging.module';
 
 const jwtConfig = AppConfig.getJWTConfig();
 
 @Module({
   imports: [
-    LoggingModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       secret: jwtConfig.secret,

--- a/api/src/modules/email/email.module.ts
+++ b/api/src/modules/email/email.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 import { IEmailServiceToken } from '@api/modules/email/email.service.interface';
 import { ConfigModule } from '@nestjs/config';
 import { EmailProviderFactory } from '@api/modules/email/email.provider';
-import { LoggingModule } from '@api/modules/logging/logging.module';
 
 @Module({
-  imports: [LoggingModule, ConfigModule],
+  imports: [ConfigModule],
   providers: [EmailProviderFactory],
   exports: [IEmailServiceToken],
 })

--- a/api/src/modules/logging/logging.module.ts
+++ b/api/src/modules/logging/logging.module.ts
@@ -1,5 +1,6 @@
-import { Logger, Module } from '@nestjs/common';
+import { Global, Logger, Module } from '@nestjs/common';
 
+@Global()
 @Module({
   providers: [Logger],
   exports: [Logger],

--- a/api/src/modules/sections/sections.module.ts
+++ b/api/src/modules/sections/sections.module.ts
@@ -4,14 +4,9 @@ import { SectionsService } from '@api/modules/sections/sections.service';
 import { Section } from '@shared/dto/sections/section.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '@api/modules/auth/auth.module';
-import { LoggingModule } from '@api/modules/logging/logging.module';
 
 @Module({
-  imports: [
-    LoggingModule,
-    TypeOrmModule.forFeature([Section]),
-    forwardRef(() => AuthModule),
-  ],
+  imports: [TypeOrmModule.forFeature([Section]), forwardRef(() => AuthModule)],
   providers: [SectionsService],
   controllers: [SectionsController],
 })

--- a/api/src/modules/users/users.module.ts
+++ b/api/src/modules/users/users.module.ts
@@ -4,14 +4,9 @@ import { UsersService } from '@api/modules/users/users.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '@shared/dto/users/user.entity';
 import { AuthModule } from '@api/modules/auth/auth.module';
-import { LoggingModule } from '@api/modules/logging/logging.module';
 
 @Module({
-  imports: [
-    LoggingModule,
-    TypeOrmModule.forFeature([User]),
-    forwardRef(() => AuthModule),
-  ],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/api/src/modules/widgets/widgets.module.ts
+++ b/api/src/modules/widgets/widgets.module.ts
@@ -5,11 +5,9 @@ import { BaseWidget } from '@shared/dto/widgets/base-widget.entity';
 import { CustomWidget } from '@shared/dto/widgets/custom-widget.entity';
 import { CustomWidgetService } from '@api/modules/widgets/custom-widgets.service';
 import { CustomWidgetsController } from '@api/modules/widgets/custom-widgets.controller';
-import { LoggingModule } from '@api/modules/logging/logging.module';
 
 @Module({
   imports: [
-    LoggingModule,
     TypeOrmModule.forFeature([BaseWidget, CustomWidget]),
     forwardRef(() => AuthModule),
   ],

--- a/api/test/app.spec.ts
+++ b/api/test/app.spec.ts
@@ -1,0 +1,33 @@
+import { DataSourceManager } from '@api/infrastructure/data-source-manager';
+import { INestApplication } from '@nestjs/common';
+import { TestManager } from 'api/test/utils/test-manager';
+
+describe('App', () => {
+  let testManager: TestManager<unknown>;
+  let testApp: INestApplication<unknown>;
+  let dataSourceManager: DataSourceManager;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager({
+      logger: false,
+      initialize: false,
+    });
+    testApp = testManager.testApp;
+    dataSourceManager = testManager.testApp.get(DataSourceManager);
+  });
+
+  afterAll(async () => {
+    await testManager.clearDatabase();
+    await testManager.close();
+  });
+
+  it('should call dataSourceManager.loadInitialData when it starts', async () => {
+    const loadInitialDataSpy = jest.spyOn(dataSourceManager, 'loadInitialData');
+
+    // When
+    await testApp.init();
+
+    // Then
+    expect(loadInitialDataSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/test/auth/auth.spec.ts
+++ b/api/test/auth/auth.spec.ts
@@ -7,7 +7,6 @@ describe('Authentication (e2e)', () => {
   beforeAll(async () => {
     testManager = await TestManager.createTestManager({ logger: false });
     fixtures = new AuthFixtures(testManager);
-    global.console.error = () => {};
   });
 
   afterEach(async () => {

--- a/api/test/data-source-manager.spec.ts
+++ b/api/test/data-source-manager.spec.ts
@@ -1,0 +1,57 @@
+import { Repository } from 'typeorm';
+import { DataSourceManager } from '@api/infrastructure/data-source-manager';
+import { TestManager } from 'api/test/utils/test-manager';
+import { Section } from '@shared/dto/sections/section.entity';
+import { BaseWidget } from '@shared/dto/widgets/base-widget.entity';
+
+describe('DataSourceManager', () => {
+  let testManager: TestManager<unknown>;
+  let dataSourceManager: DataSourceManager;
+
+  let sectionsRepository: Repository<Section>;
+  let baseWidgetsRepository: Repository<BaseWidget>;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager({
+      logger: false,
+      initialize: false,
+    });
+    dataSourceManager = testManager.testApp.get(DataSourceManager);
+
+    const dataSource = testManager.getDataSource();
+    sectionsRepository = dataSource.getRepository(Section);
+    baseWidgetsRepository = dataSource.getRepository(BaseWidget);
+  });
+
+  afterAll(async () => {
+    await testManager.clearDatabase();
+    await testManager.close();
+  });
+
+  let initialSectionCount: number;
+  let initialBaseWidgetCount: number;
+
+  it('should properly load the initial schema and data', async () => {
+    // When
+    await dataSourceManager.loadInitialData();
+
+    // Then
+    initialSectionCount = await sectionsRepository.count();
+    expect(initialSectionCount).toBeGreaterThan(0);
+
+    initialBaseWidgetCount = await baseWidgetsRepository.count();
+    expect(initialBaseWidgetCount).toBeGreaterThan(0);
+  });
+
+  it('should not insert new records on subsequent calls (idempotency test)', async () => {
+    // When
+    await dataSourceManager.loadInitialData();
+
+    // Then
+    const newSectionCount = await sectionsRepository.count();
+    expect(newSectionCount).toBe(initialSectionCount);
+
+    const newBaseWidgetCount = await baseWidgetsRepository.count();
+    expect(newBaseWidgetCount).toBe(initialBaseWidgetCount);
+  });
+});

--- a/api/test/utils/test-manager.ts
+++ b/api/test/utils/test-manager.ts
@@ -44,6 +44,7 @@ export class TestManager<FixtureType> {
     options: {
       fixtures?: FixtureType;
       logger?: Logger | false;
+      initialize?: false;
     } = {},
   ) {
     const moduleFixture = await Test.createTestingModule({
@@ -56,7 +57,9 @@ export class TestManager<FixtureType> {
       testApp.useLogger(options.logger);
     }
     testApp.useGlobalPipes(new ValidationPipe());
-    await testApp.init();
+    if (options.initialize !== false) {
+      await testApp.init();
+    }
     return new TestManager<FixtureType>(testApp, dataSource, moduleFixture);
   }
 

--- a/api/test/utils/test-manager.ts
+++ b/api/test/utils/test-manager.ts
@@ -49,12 +49,11 @@ export class TestManager<FixtureType> {
     const moduleFixture = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
-    // moduleFixture.useLogger(false);
     const dataSource = moduleFixture.get<DataSource>(getDataSourceToken());
     const testApp = moduleFixture.createNestApplication();
     if (options.logger !== undefined) {
       // Has to be called before init. Otherwise it has no effect.
-      testApp.useLogger(false);
+      testApp.useLogger(options.logger);
     }
     testApp.useGlobalPipes(new ValidationPipe());
     await testApp.init();


### PR DESCRIPTION
- test: Add tests for data-source-manager.ts and app initialization
- test: Update test Manager in order so it allows manual initialization when the instance is returned
- fix(api): When initial data is loaded, section order start at 1 instead of 2

