### PR TITLE
Apply filters to widgets

### DIFF
--- a/client/src/app/(root)/layout.tsx
+++ b/client/src/app/(root)/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 export default async function ExploreLayout({ children }: PropsWithChildren) {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
-    queryKey: queryKeys.sections.all.queryKey,
+    queryKey: queryKeys.sections.all([]).queryKey,
     queryFn: async () => client.sections.searchSections.query(QUERY_OPTIONS),
   });
   await queryClient.prefetchQuery({

--- a/client/src/containers/explore/index.tsx
+++ b/client/src/containers/explore/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { SectionWithDataWidget } from "@shared/dto/sections/section.entity";
+import { FilterQueryParam } from "@shared/schemas/query-param.schema";
 import { useSetAtom } from "jotai";
 
 import { client } from "@/lib/queryClient";
@@ -16,11 +17,10 @@ import { intersectingAtom } from "@/containers/explore/store";
 import Widget from "@/containers/widget";
 
 import { Overlay } from "@/components/ui/overlay";
-import { FilterQueryParam } from "@shared/schemas/query-param.schema";
 
 export default function Explore() {
   const { filters } = useFilters();
-  const { data, error } = client.sections.searchSections.useQuery(
+  const { data } = client.sections.searchSections.useQuery(
     queryKeys.sections.all(filters).queryKey,
     // TODO: Remove this type casting when api has updated the name property to type string
     { query: { filters: filters as FilterQueryParam<unknown> } },

--- a/client/src/containers/filter/filter-select/index.tsx
+++ b/client/src/containers/filter/filter-select/index.tsx
@@ -19,12 +19,14 @@ import { Card } from "@/components/ui/card";
 
 export interface FilterSelectProps {
   items: PageFilter[];
+  defaultValues: string[];
   fixedFilter?: PageFilter;
   onSubmit: (values: FilterSelectForm & { name: string }) => void;
 }
 
 const FilterSelect: FC<FilterSelectProps> = ({
   items,
+  defaultValues,
   fixedFilter,
   onSubmit,
 }) => {
@@ -38,6 +40,7 @@ const FilterSelect: FC<FilterSelectProps> = ({
       >
         <Card className="relative h-full bg-foreground p-0 text-background">
           <FilterSelectSteps
+            defaultValues={defaultValues}
             fixedFilter={fixedFilter}
             items={items}
             onSubmit={onSubmit}
@@ -50,6 +53,7 @@ const FilterSelect: FC<FilterSelectProps> = ({
 
 function FilterSelectSteps({
   fixedFilter,
+  defaultValues,
   items,
   onSubmit,
 }: FilterSelectProps) {
@@ -62,6 +66,8 @@ function FilterSelectSteps({
 
   return (
     <FilterSelectValues
+      items={items}
+      defaultValues={defaultValues}
       isFixedFilter={!!fixedFilter}
       onSubmit={(v) => onSubmit({ ...v, name: currentFilter?.name as string })}
     />

--- a/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
@@ -1,0 +1,108 @@
+import { FC, useState } from "react";
+
+import { PageFilter } from "@shared/dto/widgets/page-filter.entity";
+import { useSetAtom } from "jotai";
+
+import useFilters from "@/hooks/useFilters";
+
+import FilterSelect from "@/containers/filter/filter-select";
+import { isPopoverOpenAtom } from "@/containers/sidebar/store";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface FilterPopupProps {
+  name: string;
+  fixedFilter?: PageFilter;
+  items: PageFilter[];
+}
+
+const POPOVER_CONTENT_CLASS = "ml-4 h-[320px] w-full min-w-[320px]";
+
+const FilterItemButton: FC<{
+  value: string;
+
+  onClick: (value: string) => void;
+}> = ({ value, onClick }) => {
+  return (
+    <>
+      <span className="font-bold">{value}&nbsp;</span>
+      <span
+        className="h-full p-0 align-text-bottom text-xs transition-all hover:font-extrabold"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick(value);
+        }}
+      >
+        <span>x</span>
+      </span>
+    </>
+  );
+};
+
+const FilterPopup: FC<FilterPopupProps> = ({ name, fixedFilter, items }) => {
+  const { filters, addFilter, removeFilterValue } = useFilters();
+  const [showPopup, setShowPopup] = useState(false);
+  const setIsPopoverOpen = useSetAtom(isPopoverOpenAtom);
+  const handleFiltersPopupChange = (open: boolean) => {
+    setShowPopup(open);
+    setIsPopoverOpen(open);
+  };
+  const selectedFilter = filters.find((f) => f.name === name);
+
+  return (
+    <Popover onOpenChange={handleFiltersPopupChange} open={showPopup}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="clean"
+          className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary"
+        >
+          {selectedFilter ? (
+            <>
+              <span className="inline-block">
+                {name} is{" "}
+                <FilterItemButton
+                  value={selectedFilter.values[0]}
+                  onClick={(value) => removeFilterValue(name, value)}
+                />
+              </span>
+              <ul>
+                {selectedFilter.values.slice(1).map((v) => (
+                  <li key={`selected-filter-${v}`}>
+                    <FilterItemButton
+                      value={v}
+                      onClick={(value) => removeFilterValue(name, value)}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            name
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        className={POPOVER_CONTENT_CLASS}
+      >
+        <FilterSelect
+          items={items}
+          defaultValues={selectedFilter?.values || []}
+          fixedFilter={fixedFilter}
+          onSubmit={(values) => {
+            addFilter(values);
+            handleFiltersPopupChange(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default FilterPopup;

--- a/client/src/containers/sidebar/filter-settings/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/index.tsx
@@ -1,0 +1,63 @@
+import { FC } from "react";
+
+import { client } from "@/lib/queryClient";
+import { queryKeys } from "@/lib/queryKeys";
+
+import useFilters from "@/hooks/useFilters";
+
+import FilterPopup from "@/containers/sidebar/filter-settings/filter-popup";
+
+import { Button } from "@/components/ui/button";
+
+const DEFAULT_FILTERS = ["eu-member-state", "type-of-data"];
+
+const FilterSettings: FC = () => {
+  const { filters } = useFilters();
+  const filtersQuery = client.pageFilter.searchFilters.useQuery(
+    queryKeys.pageFilters.all.queryKey,
+    {},
+    { select: (res) => res.body.data },
+  );
+  const selectedCustomFilters = filters.filter(
+    (f) => !DEFAULT_FILTERS.includes(f.name),
+  );
+  const customFilters =
+    filtersQuery.data?.filter((f) => !DEFAULT_FILTERS.includes(f.name)) || [];
+
+  return (
+    <>
+      {filtersQuery.data
+        ?.filter((pageFilter) => DEFAULT_FILTERS.includes(pageFilter.name))
+        .map((f) => (
+          <FilterPopup
+            key={`sidebar-filter-popover-${f.name}`}
+            name={f.name}
+            items={filtersQuery.data || []}
+            fixedFilter={f}
+          />
+        ))}
+
+      {selectedCustomFilters.map((f) => (
+        <FilterPopup
+          key={`sidebar-filter-popover-${f.name}`}
+          name={f.name}
+          items={customFilters}
+          fixedFilter={f}
+        />
+      ))}
+      <FilterPopup
+        key="sidebar-filter-popover-custom"
+        name="Add a custom filter"
+        items={customFilters}
+      />
+      <Button
+        variant="clean"
+        className="w-full justify-start rounded-none px-4 py-3.5 font-normal transition-colors hover:bg-secondary"
+      >
+        Add a data breakdown
+      </Button>
+    </>
+  );
+};
+
+export default FilterSettings;

--- a/client/src/containers/sidebar/index.tsx
+++ b/client/src/containers/sidebar/index.tsx
@@ -8,6 +8,8 @@ import { useAtomValue } from "jotai";
 
 import { cn } from "@/lib/utils";
 
+import useFilters from "@/hooks/useFilters";
+
 import Header from "@/containers/header";
 import FilterSettings from "@/containers/sidebar/filter-settings";
 import SectionsNav from "@/containers/sidebar/sections-nav";
@@ -26,6 +28,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 const Sidebar: FC = () => {
   const isExplore = usePathname().startsWith("/explore");
   const isPopoverOpen = useAtomValue(isPopoverOpenAtom);
+  const { filters } = useFilters();
 
   return (
     <>
@@ -53,7 +56,11 @@ const Sidebar: FC = () => {
             key="sidebar-accordion-explore"
             type="multiple"
             className="w-full overflow-y-auto"
-            defaultValue={["explore-sections"]}
+            defaultValue={
+              filters.length
+                ? ["explore-filters", "explore-sections"]
+                : ["explore-sections"]
+            }
           >
             <AccordionItem value="explore-filters">
               <AccordionTrigger>Filters</AccordionTrigger>

--- a/client/src/containers/sidebar/index.tsx
+++ b/client/src/containers/sidebar/index.tsx
@@ -1,18 +1,17 @@
 "use client";
-import { FC, useState } from "react";
+import { FC } from "react";
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { useAtomValue } from "jotai";
 
-import { client } from "@/lib/queryClient";
-import { queryKeys } from "@/lib/queryKeys";
 import { cn } from "@/lib/utils";
 
-import { intersectingAtom } from "@/containers/explore/store";
-import FilterSelect from "@/containers/filter/filter-select";
 import Header from "@/containers/header";
+import FilterSettings from "@/containers/sidebar/filter-settings";
+import SectionsNav from "@/containers/sidebar/sections-nav";
+import { isPopoverOpenAtom } from "@/containers/sidebar/store";
 
 import {
   Accordion,
@@ -22,30 +21,11 @@ import {
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { Overlay } from "@/components/ui/overlay";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-const DEFAULT_FILTERS = ["eu-member-state", "type-of-data"];
-const POPOVER_CONTENT_CLASS = "ml-4 h-[320px] w-full min-w-[320px]";
-
 const Sidebar: FC = () => {
-  const sectionsQuery = client.sections.searchSections.useQuery(
-    queryKeys.sections.all.queryKey,
-    { query: {} },
-    { select: (res) => res.body.data },
-  );
-  const filtersQuery = client.pageFilter.searchFilters.useQuery(
-    queryKeys.pageFilters.all.queryKey,
-    {},
-    { select: (res) => res.body.data },
-  );
   const isExplore = usePathname().startsWith("/explore");
-  const intersecting = useAtomValue(intersectingAtom);
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const isPopoverOpen = useAtomValue(isPopoverOpenAtom);
 
   return (
     <>
@@ -78,85 +58,13 @@ const Sidebar: FC = () => {
             <AccordionItem value="explore-filters">
               <AccordionTrigger>Filters</AccordionTrigger>
               <AccordionContent className="py-3.5">
-                {filtersQuery.data
-                  ?.filter((pageFilter) =>
-                    DEFAULT_FILTERS.includes(pageFilter.name),
-                  )
-                  .map((f) => (
-                    <Popover
-                      key={`sidebar-filter-popover-${f.name}`}
-                      onOpenChange={setIsPopoverOpen}
-                    >
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="clean"
-                          className="w-full justify-start rounded-none px-4 py-3.5 font-normal transition-colors hover:bg-secondary"
-                        >
-                          {f.name}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent
-                        align="end"
-                        side="bottom"
-                        className={POPOVER_CONTENT_CLASS}
-                      >
-                        <FilterSelect
-                          items={filtersQuery.data || []}
-                          fixedFilter={f}
-                          onSubmit={() => {
-                            // TODO: implemenation will be added in seperate PR
-                          }}
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  ))}
-                <Popover onOpenChange={setIsPopoverOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="clean"
-                      className="w-full justify-start rounded-none px-4 py-3.5 font-normal transition-colors hover:bg-secondary"
-                    >
-                      Add a custom filter
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    align="end"
-                    side="bottom"
-                    className={POPOVER_CONTENT_CLASS}
-                  >
-                    <FilterSelect
-                      items={filtersQuery.data || []}
-                      onSubmit={() => {
-                        // TODO: implemenation will be added in seperate PR
-                      }}
-                    />
-                  </PopoverContent>
-                </Popover>
-
-                <Button
-                  variant="clean"
-                  className="w-full justify-start rounded-none px-4 py-3.5 font-normal transition-colors hover:bg-secondary"
-                >
-                  Add a data breakdown
-                </Button>
+                <FilterSettings />
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="explore-sections">
               <AccordionTrigger>Sections</AccordionTrigger>
               <AccordionContent className="py-3.5" id="sidebar-sections-list">
-                {sectionsQuery.data?.map((s) => (
-                  <Link
-                    key={`section-link-${s.slug}`}
-                    className={cn(
-                      "block transition-colors hover:bg-secondary",
-                      intersecting === s.slug &&
-                        "border-l-2 border-white bg-secondary",
-                    )}
-                    href={`#${s.slug}`}
-                  >
-                    <div className="px-4 py-3.5">{s.name}</div>
-                  </Link>
-                ))}
+                <SectionsNav />
               </AccordionContent>
             </AccordionItem>
           </Accordion>
@@ -176,7 +84,7 @@ const Sidebar: FC = () => {
             <AccordionItem value="sandbox-filters">
               <AccordionTrigger>Filters</AccordionTrigger>
               <AccordionContent className="py-3.5">
-                filters here...
+                <FilterSettings />
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/client/src/containers/sidebar/sections-nav/index.tsx
+++ b/client/src/containers/sidebar/sections-nav/index.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react";
+
+import Link from "next/link";
+
+import { useAtomValue } from "jotai";
+
+import { client } from "@/lib/queryClient";
+import { queryKeys } from "@/lib/queryKeys";
+import { cn } from "@/lib/utils";
+
+import { intersectingAtom } from "@/containers/explore/store";
+
+const SectionsNav: FC = () => {
+  const sectionsQuery = client.sections.searchSections.useQuery(
+    queryKeys.sections.all([]).queryKey,
+    { query: {} },
+    { select: (res) => res.body.data },
+  );
+  const intersecting = useAtomValue(intersectingAtom);
+
+  return (
+    <>
+      {sectionsQuery.data?.map((s) => (
+        <Link
+          key={`section-link-${s.slug}`}
+          className={cn(
+            "block transition-colors hover:bg-secondary",
+            intersecting === s.slug && "border-l-2 border-white bg-secondary",
+          )}
+          href={`#${s.slug}`}
+        >
+          <div className="px-4 py-3.5">{s.name}</div>
+        </Link>
+      ))}
+    </>
+  );
+};
+
+export default SectionsNav;

--- a/client/src/containers/sidebar/store.ts
+++ b/client/src/containers/sidebar/store.ts
@@ -1,0 +1,3 @@
+import { atom } from "jotai";
+
+export const isPopoverOpenAtom = atom<boolean>(false);

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -3,6 +3,8 @@ import {
   mergeQueryKeys,
 } from "@lukemorales/query-key-factory";
 
+import { FilterQueryParam } from "@/hooks/useFilters";
+
 export const usersKeys = createQueryKeys("users", {
   detail: (userId: string) => [userId],
   userCharts: (userId: string, options: Record<string, unknown>) => [
@@ -12,7 +14,9 @@ export const usersKeys = createQueryKeys("users", {
 });
 
 export const sectionsKeys = createQueryKeys("sections", {
-  all: null,
+  all: (filters: FilterQueryParam[]) => ({
+    queryKey: [{ filters }],
+  }),
 });
 
 export const pageFiltersKeys = createQueryKeys("pageFilters", {

--- a/client/tests/filter-select/filter-select-values.test.tsx
+++ b/client/tests/filter-select/filter-select-values.test.tsx
@@ -20,13 +20,25 @@ vi.mock("@/containers/filter/filter-select/filter-select-operator", () => ({
 }));
 
 describe("FilterSelectValues", () => {
+  const mockItems = [
+    {
+      name: "sector",
+      values: ["Agriculture", "Forestry"],
+    },
+    {
+      name: "level-of-reliability:-1-5",
+      values: ["1", "2", "3", "4", "5"],
+    },
+  ];
   const mockFilter = {
     name: "sector",
-    values: ["Agriculture", "Forestry", "Both"],
+    values: ["Agriculture", "Forestry"],
   };
 
   const mockOnSubmit = vi.fn();
   const mockProps = {
+    items: mockItems,
+    defaultValues: [],
     onSubmit: mockOnSubmit,
   };
 
@@ -94,6 +106,32 @@ describe("FilterSelectValues", () => {
       expect(screen.queryByText("Agriculture")).not.toBeInTheDocument();
       expect(screen.queryByText("Both")).not.toBeInTheDocument();
     });
+  });
+
+  it("should unselect all checkboxes if defaultValues is empty", () => {
+    render(<FilterSelectValues {...mockProps} defaultValues={[]} />);
+
+    expect(screen.getByLabelText("Agriculture")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByLabelText("Forestry")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("should select the correct checkboxes if defaultValues is passed", () => {
+    render(<FilterSelectValues {...mockProps} defaultValues={["Forestry"]} />);
+
+    expect(screen.getByLabelText("Agriculture")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByLabelText("Forestry")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
   });
 
   it("toggles select all checkbox", () => {

--- a/client/tests/hooks/useFilters.test.ts
+++ b/client/tests/hooks/useFilters.test.ts
@@ -8,10 +8,6 @@ vi.mock("nuqs", () => ({
   useQueryState: vi.fn(),
 }));
 
-vi.mock("@shared/dto/widgets/page-filter-question-map", () => ({
-  AVAILABLE_PAGE_FILTER_NAMES: ["sector", "eu-member-state"],
-}));
-
 vi.mock("@shared/dto/global/search-widget-data-params", () => ({
   VALID_SEARCH_WIDGET_DATA_OPERATORS: ["=", "!="],
 }));
@@ -39,7 +35,7 @@ describe("useFilters", () => {
 
   it("should parse and validate filters from filtersQuery", () => {
     const validFiltersQuery =
-      "filters[0][name]=sector&filters[0][operator]==&filters[0][value][0]=value1";
+      "filters[0][name]=sector&filters[0][operator]==&filters[0][values][0]=value1";
     const mockSetFiltersQuery = vi.fn();
     (useQueryState as jest.Mock).mockReturnValue([
       validFiltersQuery,
@@ -49,7 +45,7 @@ describe("useFilters", () => {
     const { result } = renderHook(() => useFilters());
 
     expect(result.current.filters).toEqual([
-      { name: "sector", operator: "=", value: ["value1"] },
+      { name: "sector", operator: "=", values: ["value1"] },
     ]);
   });
 
@@ -61,12 +57,12 @@ describe("useFilters", () => {
 
     act(() => {
       result.current.setFilters([
-        { name: "sector", operator: "=", value: ["newValue"] },
+        { name: "sector", operator: "=", values: ["newValue"] },
       ]);
     });
 
     expect(mockSetFiltersQuery).toHaveBeenCalledWith(
-      "filters[0][name]=sector&filters[0][operator]==&filters[0][value][0]=newValue",
+      "filters[0][name]=sector&filters[0][operator]==&filters[0][values][0]=newValue",
     );
   });
 
@@ -113,38 +109,32 @@ describe("useFilters", () => {
   );
 
   testInvalidFilter(
-    "invalid name",
-    "filters[0][name]=invalidName&filters[0][operator]==&filters[0][value][]=value1",
-    "Filter at index 0 has invalid 'name': \"invalidName\"",
-  );
-
-  testInvalidFilter(
     "invalid operator",
-    "filters[0][name]=sector&filters[0][operator]=>&filters[0][value][]=value1",
+    "filters[0][name]=sector&filters[0][operator]=>&filters[0][values][]=value1",
     "Filter at index 0 has invalid 'operator': \">\"",
   );
 
   testInvalidFilter(
     "missing name",
-    "filters[0][operator]==&filters[0][value][]=value1",
+    "filters[0][operator]==&filters[0][values][]=value1",
     "Filter at index 0 is missing required keys: name",
   );
 
   testInvalidFilter(
     "missing operator",
-    "filters[0][name]=sector&filters[0][value][]=value1",
+    "filters[0][name]=sector&filters[0][values][]=value1",
     "Filter at index 0 is missing required keys: operator",
   );
 
   testInvalidFilter(
-    "missing value",
+    "missing values",
     "filters[0][name]=sector&filters[0][operator]==",
-    "Filter at index 0 is missing required keys: value",
+    "Filter at index 0 is missing required keys: values",
   );
 
   testInvalidFilter(
-    "empty value array",
-    "filters[0][name]=sector&filters[0][operator]==&filters[0][value]=",
-    "Filter at index 0 has invalid 'value': expected a non-empty array",
+    "empty values array",
+    "filters[0][name]=sector&filters[0][operator]==&filters[0][values]=",
+    "Filter at index 0 has invalid 'values': expected a non-empty array",
   );
 });


### PR DESCRIPTION
## Apply filters to widgets

### Overview

- Filters can now be added/removed which will auto-update the url + state 
- Validation for filter name has been removed, since this will be of type string in the near future
- Invalid filters will currently return an error message response from the API, but to keep the frontend state easily in sync with the backend the API response will (soon) return all sections and only filter the widget data

### Testing instructions

- The following filters can be used to test: eu-member-state (France,Spain), sector

### Feature relevant tickets

[SIRH-126](https://vizzuality.atlassian.net/browse/SIRH-126)


[SIRH-126]: https://vizzuality.atlassian.net/browse/SIRH-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ