### PR TITLE
fixes visualisation filter required for widgets

### DIFF
--- a/api/src/modules/sections/sections.controller.ts
+++ b/api/src/modules/sections/sections.controller.ts
@@ -10,9 +10,9 @@ export class SectionsController {
   public constructor(private readonly sectionsService: SectionsService) {}
 
   @Public()
-  @TsRestHandler(c.searchSections)
-  public async searchSections(): Promise<ControllerResponse> {
-    return tsRestHandler(c.searchSections, async ({ query }) => {
+  @TsRestHandler(c.getSections)
+  public async getSections(): Promise<ControllerResponse> {
+    return tsRestHandler(c.getSections, async ({ query }) => {
       // TODO: There is a bug / weird behavior in typeorm when using take and skip with leftJoinAndSelect:
       //       https://github.com/typeorm/typeorm/issues/4742#issuecomment-780702477
       //       Since we don't need pagination for this endpoint, we can disable it for now but worth checking

--- a/api/src/modules/widgets/widgets.service.ts
+++ b/api/src/modules/widgets/widgets.service.ts
@@ -27,24 +27,13 @@ export class WidgetsService extends AppBaseService<
     query: SelectQueryBuilder<BaseWidget>,
     fetchSpecification: FetchSpecification & WidgetVisualisationFilters,
   ): Promise<SelectQueryBuilder<BaseWidget>> {
-    if (fetchSpecification?.visualisations.length) {
+    if (fetchSpecification?.visualisations?.length) {
       return this.filterByVisualisation(
         query,
         fetchSpecification.visualisations,
       );
     }
-  }
-
-  async extendGetByIdQuery(
-    query: SelectQueryBuilder<BaseWidget>,
-    fetchSpecification?: FetchSpecification & WidgetVisualisationFilters,
-  ): Promise<SelectQueryBuilder<BaseWidget>> {
-    if (fetchSpecification?.visualisations.length) {
-      return this.filterByVisualisation(
-        query,
-        fetchSpecification.visualisations,
-      );
-    }
+    return query;
   }
 
   private filterByVisualisation(

--- a/client/src/app/(root)/layout.tsx
+++ b/client/src/app/(root)/layout.tsx
@@ -17,7 +17,7 @@ export default async function ExploreLayout({ children }: PropsWithChildren) {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
     queryKey: queryKeys.sections.all([]).queryKey,
-    queryFn: async () => client.sections.searchSections.query(QUERY_OPTIONS),
+    queryFn: async () => client.sections.getSections.query(QUERY_OPTIONS),
   });
   await queryClient.prefetchQuery({
     queryKey: queryKeys.pageFilters.all.queryKey,

--- a/client/src/containers/explore/index.tsx
+++ b/client/src/containers/explore/index.tsx
@@ -20,7 +20,7 @@ import { Overlay } from "@/components/ui/overlay";
 
 export default function Explore() {
   const { filters } = useFilters();
-  const { data } = client.sections.searchSections.useQuery(
+  const { data } = client.sections.getSections.useQuery(
     queryKeys.sections.all(filters).queryKey,
     // TODO: Remove this type casting when api has updated the name property to type string
     { query: { filters: filters as FilterQueryParam<unknown> } },

--- a/client/src/containers/sidebar/sections-nav/index.tsx
+++ b/client/src/containers/sidebar/sections-nav/index.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { intersectingAtom } from "@/containers/explore/store";
 
 const SectionsNav: FC = () => {
-  const sectionsQuery = client.sections.searchSections.useQuery(
+  const sectionsQuery = client.sections.getSections.useQuery(
     queryKeys.sections.all([]).queryKey,
     { query: {} },
     { select: (res) => res.body.data },

--- a/shared/contracts/sections.contract.ts
+++ b/shared/contracts/sections.contract.ts
@@ -7,7 +7,7 @@ import { initContract } from '@ts-rest/core';
 
 const contract = initContract();
 export const sectionContract = contract.router({
-  searchSections: {
+  getSections: {
     method: 'GET',
     path: '/sections',
     query: generateEntityQuerySchema(SectionWithDataWidget).merge(

--- a/shared/schemas/widget-visualisation-filters.schema.ts
+++ b/shared/schemas/widget-visualisation-filters.schema.ts
@@ -5,9 +5,9 @@ import {
 } from '@shared/dto/widgets/widget-visualizations.constants';
 
 export const WidgetVisualizationFilterSchema = z.object({
-  visualisations: z.array(
-    z.enum(VALID_WIDGET_VISUALIZATIONS as [WidgetVisualizationsType]),
-  ),
+  visualisations: z
+    .array(z.enum(VALID_WIDGET_VISUALIZATIONS as [WidgetVisualizationsType]))
+    .optional(),
 });
 
 export type WidgetVisualisationFilters = z.infer<


### PR DESCRIPTION
This pull request includes changes to the `WidgetsService` class, test cases for base widgets, and the widget visualization filter schema. The most important changes involve refactoring the `extendGetByIdQuery` method, adding a new test case, and making the `visualisations` array optional in the schema.

Refactoring and bug fixes:

* [`api/src/modules/widgets/widgets.service.ts`](diffhunk://#diff-a0170ae4a17f3df69749240e00c40c602ef93f54e8c63ad0eeba0381cc351786L30-R36): Refactored the `extendGetByIdQuery` method to handle cases where `fetchSpecification.visualisations` is undefined or empty, ensuring the query is always returned.

Testing improvements:

* [`api/test/e2e/widgets/base-widgets.spec.ts`](diffhunk://#diff-db7a15d5bd306a7fc40647f0523161f51c760a6ff4efe993286edf5e5252b10fR3-R45): Added a new test case to verify that all base widgets are correctly retrieved and match the loaded initial data.

Schema updates:

* [`shared/schemas/widget-visualisation-filters.schema.ts`](diffhunk://#diff-287ba9a02b949ddd13ebc546e02ebb283e312cf6e6f7c2368374e5712d3aec47L8-R10): Modified the `visualisations` array in the `WidgetVisualizationFilterSchema` to be optional, improving flexibility in the filter criteria.