### PR TITLE
Refactor E2E tests to support production-like database state

### DIFF
--- a/client/src/containers/explore/section/index.tsx
+++ b/client/src/containers/explore/section/index.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 
 import { Section as SectionEntity } from "@shared/dto/sections/section.entity";
 
+import { getInPageLinkId, getSidebarLinkId } from "@/lib/utils";
+
 import SectionNavigator from "@/components/icons/section-navigator";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -48,7 +50,11 @@ const Section: React.FC<PropsWithChildren<SectionProps>> = ({
   };
 
   return (
-    <section className="mb-16" id={slug}>
+    <section
+      className="mb-16"
+      id={slug}
+      aria-labelledby={`${getSidebarLinkId(slug)} ${getInPageLinkId(slug)}`}
+    >
       {isOverview ? (
         <div className="col-span-2 mb-0.5 grid grid-cols-2 gap-0.5">
           <Card className="space-y-4 bg-secondary">

--- a/client/src/containers/explore/section/overview-section/index.tsx
+++ b/client/src/containers/explore/section/overview-section/index.tsx
@@ -74,7 +74,7 @@ const OverviewSection: FC<OverviewSectionProps> = ({
           />
         </Card>
         <div className="grid grid-rows-2 gap-0.5">
-          <div className="flex gap-0.5">
+          <div className="flex gap-0.5" data-testid="overview-single-values">
             <Widget
               defaultVisualization={widgets[1].defaultVisualization}
               visualisations={widgets[1].visualisations}

--- a/client/src/containers/explore/section/tile-menu/index.tsx
+++ b/client/src/containers/explore/section/tile-menu/index.tsx
@@ -2,7 +2,11 @@ import { FC } from "react";
 
 import Link from "next/link";
 
-import { cn } from "@/lib/utils";
+import { useAtomValue } from "jotai";
+
+import { cn, getInPageLinkId } from "@/lib/utils";
+
+import { intersectingAtom } from "@/containers/explore/store";
 
 import { Card } from "@/components/ui/card";
 import Title from "@/components/ui/title";
@@ -18,14 +22,29 @@ interface TileMenuProps {
 }
 
 const TileMenu: FC<TileMenuProps> = ({ items, className }) => {
+  const intersecting = useAtomValue(intersectingAtom);
+
   return (
-    <div className={cn("grid grid-cols-3 gap-0.5", className)}>
+    <nav
+      id="in-page-sections-list"
+      aria-labelledby="in-page-nav-title"
+      className={cn("grid grid-cols-3 gap-0.5", className)}
+    >
+      <h2 id="in-page-nav-title" className="sr-only">
+        Sections navigation
+      </h2>
       {items.map((i) => (
         <Card
           key={`tile-menu-${i.slug}`}
           className="space-y-6 bg-primary p-0 transition-colors hover:bg-secondary"
         >
-          <Link className="flex-1 p-6" href={`#${i.slug}`}>
+          <Link
+            className="flex-1 p-6"
+            href={`#${i.slug}`}
+            id={getInPageLinkId(i.slug)}
+            aria-controls={i.slug}
+            aria-current={intersecting === i.slug ? "true" : undefined}
+          >
             <Title as="h3" className="text-base">
               {i.name}
             </Title>
@@ -33,7 +52,7 @@ const TileMenu: FC<TileMenuProps> = ({ items, className }) => {
           </Link>
         </Card>
       ))}
-    </div>
+    </nav>
   );
 };
 

--- a/client/src/containers/sidebar/sections-nav/index.tsx
+++ b/client/src/containers/sidebar/sections-nav/index.tsx
@@ -6,7 +6,7 @@ import { useAtomValue } from "jotai";
 
 import { client } from "@/lib/queryClient";
 import { queryKeys } from "@/lib/queryKeys";
-import { cn } from "@/lib/utils";
+import { cn, getSidebarLinkId } from "@/lib/utils";
 
 import { intersectingAtom } from "@/containers/explore/store";
 
@@ -19,20 +19,30 @@ const SectionsNav: FC = () => {
   const intersecting = useAtomValue(intersectingAtom);
 
   return (
-    <>
-      {sectionsQuery.data?.map((s) => (
-        <Link
-          key={`section-link-${s.slug}`}
-          className={cn(
-            "block transition-colors hover:bg-secondary",
-            intersecting === s.slug && "border-l-2 border-white bg-secondary",
-          )}
-          href={`#${s.slug}`}
-        >
-          <div className="px-4 py-3.5">{s.name}</div>
-        </Link>
-      ))}
-    </>
+    <nav aria-labelledby="sidebar-nav-title">
+      <h2 id="sidebar-nav-title" className="sr-only">
+        Sections navigation
+      </h2>
+      <ol role="list">
+        {sectionsQuery.data?.map((s) => (
+          <li key={`section-link-${s.slug}`} role="listitem">
+            <Link
+              className={cn(
+                "block transition-colors hover:bg-secondary",
+                intersecting === s.slug &&
+                  "border-l-2 border-white bg-secondary",
+              )}
+              href={`#${s.slug}`}
+              id={getSidebarLinkId(s.slug)}
+              aria-controls={s.slug}
+              aria-current={intersecting === s.slug ? "true" : undefined}
+            >
+              <div className="px-4 py-3.5">{s.name}</div>
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </nav>
   );
 };
 

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -6,6 +6,10 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export const getSidebarLinkId = (slug?: string): string =>
+  `sidebar-${slug}-link`;
+export const getInPageLinkId = (slug?: string): string => `inPage-${slug}-link`;
+
 export function isEmptyWidget(data: BaseWidgetWithData["data"]): boolean {
   return Object.keys(data).length === 0;
 }

--- a/e2e/tests/auth/auth.spec.ts
+++ b/e2e/tests/auth/auth.spec.ts
@@ -2,66 +2,39 @@ import { test, expect } from '@playwright/test';
 import { E2eTestManager } from '@shared/lib/e2e-test-manager';
 import { CreateUserDto } from '@shared/dto/users/create-user.dto';
 
-let testManager: E2eTestManager;
-
-test.beforeAll(async () => {
-  testManager = await E2eTestManager.load();
-});
-
-test.beforeEach(async () => {
-  await testManager.clearDatabase();
-});
-
-test.afterEach(async () => {
-  await testManager.clearDatabase();
-});
-
-test.afterAll(async () => {
-  await testManager.close();
-});
-
-test('an user signs up successfully', async ({ page }) => {
-  const user: CreateUserDto = {
-    email: 'johndoe@test.com',
+test.describe('Authentication', () => {
+  let testManager: E2eTestManager;
+  let user: CreateUserDto = {
+    email: `test-${Date.now()}@test.com`,
     password: 'password',
   };
 
-  await page.goto('/auth/signup');
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    testManager = await E2eTestManager.load(page);
+  });
 
-  await page.getByLabel('Email').fill(user.email);
-  await page.locator('input[type="password"]').fill(user.password);
-  await page.getByRole('checkbox').check();
+  test.afterAll(async () => {
+    await testManager.logout();
+    await testManager.deleteUserByEmail(user.email);
+    await testManager.close();
+  });
 
-  await page.getByRole('button', { name: /sign up/i }).click();
+  test('a user signs up and signs in successfully', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await page.getByLabel('Email').fill(user.email);
+    await page.locator('input[type="password"]').fill(user.password);
+    await page.getByRole('checkbox').check();
+    await page.getByRole('button', { name: /sign up/i }).click();
 
-  await page.waitForURL('/auth/signin');
+    await page.waitForURL('/auth/signin');
 
-  await page.getByLabel('Email').fill(user.email);
-  await page.locator('input[type="password"]').fill(user.password);
+    await page.getByLabel('Email').fill(user.email);
+    await page.locator('input[type="password"]').fill(user.password);
 
-  await page.getByRole('button', { name: /log in/i }).click();
+    await page.getByRole('button', { name: /log in/i }).click();
 
-  await page.waitForURL('/profile');
-  await expect(await page.locator('input[type="email"]')).toHaveValue(
-    user.email
-  );
-});
-
-test('an user signs in successfully', async ({ page }) => {
-  const user: CreateUserDto = {
-    email: 'jhondoe@test.com',
-    password: '12345678',
-  };
-
-  await testManager.mocks().createUser({ email: user.email });
-
-  await page.goto('/auth/signin');
-  await page.getByLabel('Email').fill(user.email);
-  await page.locator('input[type="password"]').fill(user.password);
-  await page.getByRole('button', { name: /log in/i }).click();
-
-  await page.waitForURL('/profile');
-  await expect(await page.locator('input[type="email"]')).toHaveValue(
-    user.email
-  );
+    await page.waitForURL('/profile');
+    await expect(page.locator('input[type="email"]')).toHaveValue(user.email);
+  });
 });

--- a/e2e/tests/auth/password-recovery.spec.ts
+++ b/e2e/tests/auth/password-recovery.spec.ts
@@ -1,13 +1,17 @@
 import { test, expect, Page } from '@playwright/test';
 import { E2eTestManager } from '@shared/lib/e2e-test-manager';
 import { User } from '@shared/dto/users/user.entity';
+import { CreateUserDto } from '@shared/dto/users/create-user.dto';
 
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Password Recovery E2E', () => {
   let testManager: E2eTestManager;
   let page: Page;
-  let user: User;
+  let user: CreateUserDto = {
+    email: `test-${Date.now()}@test.com`,
+    password: 'password',
+  };
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
@@ -15,26 +19,23 @@ test.describe('Password Recovery E2E', () => {
   });
 
   test.beforeEach(async () => {
-   user = await testManager.mocks().createUser()
-  });
-
-  test.afterEach(async () => {
-    await testManager.clearDatabase();
+    user = await testManager.mocks().createUser();
   });
 
   test.afterAll(async () => {
     await testManager.logout();
+    await testManager.deleteUserByEmail(user.email);
     await testManager.close();
   });
 
   test('an email should be sent when requesting a password recovery', async () => {
-      await testManager.page.goto('/auth/signin');
-      await page.getByRole('link', { name: 'Forgot password?' }).click();
-      await page.getByPlaceholder('Enter your email').click();
-      await page.getByPlaceholder('Enter your email').fill(user.email);
-      await page.getByRole('button', { name: 'Send link' }).click();
-      await expect(page.getByRole('status').first()).toHaveText(
-      'Check your inbox for a password reset link.'
+    await testManager.page.goto('/auth/signin');
+    await page.getByRole('link', { name: 'Forgot password?' }).click();
+    await page.getByPlaceholder('Enter your email').click();
+    await page.getByPlaceholder('Enter your email').fill(user.email);
+    await page.getByRole('button', { name: 'Send link' }).click();
+    await expect(page.getByRole('status').first()).toHaveText(
+      'Check your inbox for a password reset link.',
     );
   });
 });

--- a/e2e/tests/custom-widgets/custom-widgets.spec.ts
+++ b/e2e/tests/custom-widgets/custom-widgets.spec.ts
@@ -1,14 +1,16 @@
-import { test, expect, Page } from "@playwright/test";
-import { E2eTestManager } from "@shared/lib/e2e-test-manager";
-import { User } from "@shared/dto/users/user.entity";
-import { CustomWidget } from "@shared/dto/widgets/custom-widget.entity";
+import { test, expect, Page } from '@playwright/test';
+import { E2eTestManager } from '@shared/lib/e2e-test-manager';
+import { User } from '@shared/dto/users/user.entity';
+import { CustomWidget } from '@shared/dto/widgets/custom-widget.entity';
+import { In } from 'typeorm';
 
-test.describe.configure({ mode: "serial" });
+test.describe.configure({ mode: 'serial' });
 
-test.describe("Custom Charts E2E", () => {
+test.describe('Custom Charts E2E', () => {
   let testManager: E2eTestManager;
   let page: Page;
   let user: User;
+  let customWidgets: CustomWidget[] = [];
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
@@ -20,7 +22,15 @@ test.describe("Custom Charts E2E", () => {
   });
 
   test.afterEach(async () => {
-    await testManager.clearDatabase();
+    await testManager.deleteUserByEmail(user.email);
+
+    if (customWidgets.length > 0) {
+      await testManager.dataSource.getRepository(CustomWidget).delete({
+        id: In(customWidgets.map((widget) => widget.id)),
+      });
+
+      customWidgets = [];
+    }
   });
 
   test.afterAll(async () => {
@@ -28,57 +38,59 @@ test.describe("Custom Charts E2E", () => {
     await testManager.close();
   });
 
-  test.describe("List Custom Charts", () => {
-    let customCharts: CustomWidget[] = [];
+  test.describe('List Custom Charts', () => {
     test.beforeEach(async () => {
       for (const n of Array(10).keys()) {
-        customCharts.push(
-          await testManager.mocks().createCustomWidget({
-            name: `Test chart ${n}`,
-            user: { id: user.id },
-          })
-        );
+        const widget = await testManager.mocks().createCustomWidget({
+          name: `Test chart ${n}`,
+          user: { id: user.id },
+        });
+        customWidgets.push(widget);
       }
     });
-    test("a user can see a list of custom charts", async () => {
+    test('a user can see a list of custom charts', async () => {
       // TODO: Implement test for listing created charts
     });
   });
-  test.describe("Rename Custom Chart", () => {
-    test("a user can rename a custom chart", async () => {
-      const CustomWidget = await testManager
+
+  test.describe('Rename Custom Chart', () => {
+    test('a user can rename a custom chart', async () => {
+      const widget = await testManager
         .mocks()
         .createCustomWidget({ user: { id: user.id } });
-      await page.goto("/profile");
+      customWidgets.push(widget);
+
+      await page.goto('/profile');
       await page
-        .getByRole("cell", { name: CustomWidget.defaultVisualization })
-        .getByRole("button")
+        .getByRole('cell', { name: widget.defaultVisualization })
+        .getByRole('button')
         .click();
-      await page.getByRole("button", { name: "Rename" }).click();
-      await page.locator('input[type="text"]').fill("Cahnge");
-      await page.locator('input[type="text"]').press("Enter");
-      await expect(page.getByRole("status").first()).toHaveText(
-        "Visualization updated successfully."
+      await page.getByRole('button', { name: 'Rename' }).click();
+      await page.locator('input[type="text"]').fill('Change');
+      await page.locator('input[type="text"]').press('Enter');
+      await expect(page.getByRole('status').first()).toHaveText(
+        'Visualization updated successfully.',
       );
     });
   });
-  test.describe("Delete Custom Chart", () => {
-    test("a user can delete a custom chart", async () => {
-      const CustomWidget = await testManager
+
+  test.describe('Delete Custom Chart', () => {
+    test('a user can delete a custom chart', async () => {
+      const widget = await testManager
         .mocks()
         .createCustomWidget({ user: { id: user.id } });
-      await page.goto("/profile");
+      customWidgets.push(widget);
+
+      await page.goto('/profile');
       await page
-        .getByRole("cell", { name: CustomWidget.defaultVisualization })
-        .getByRole("button")
+        .getByRole('cell', { name: widget.defaultVisualization })
+        .getByRole('button')
         .click();
-      await page.getByRole("button", { name: "Delete", exact: true }).click();
-      await page.getByRole("button", { name: "Delete visualization" }).click();
-      await expect(page.getByRole("status").first()).toHaveText(
-        "Visualization removed successfully."
+      await page.getByRole('button', { name: 'Delete', exact: true }).click();
+      await page.getByRole('button', { name: 'Delete visualization' }).click();
+      await expect(page.getByRole('status').first()).toHaveText(
+        'Visualization removed successfully.',
       );
-      // await page.getByRole('status').click();
-      // await page.getByText('Visualization removed').click();
     });
   });
 });

--- a/e2e/tests/explore/explore.spec.ts
+++ b/e2e/tests/explore/explore.spec.ts
@@ -1,56 +1,143 @@
-import { test, Page, expect } from '@playwright/test'
-import { Section } from '@shared/dto/sections/section.entity'
-import { E2eTestManager } from '@shared/lib/e2e-test-manager'
+import { test as base, expect } from '@playwright/test';
+import { Section } from '@shared/dto/sections/section.entity';
+import { PageFilter } from '@shared/dto/widgets/page-filter.entity';
+import { E2eTestManager } from '@shared/lib/e2e-test-manager';
 
-test.describe.configure({ mode: 'serial' })
+type TestFixtures = {
+  testManager: E2eTestManager;
+  sections: Section[];
+  requiredFilter: PageFilter;
+};
+
+const test = base.extend<TestFixtures>({
+  testManager: async ({ page }, use) => {
+    const manager = await E2eTestManager.load(page);
+    await use(manager);
+    await manager.close();
+  },
+
+  sections: async ({ testManager }, use) => {
+    const sections = await testManager.dataSource.getRepository(Section).find();
+
+    if (sections.length === 0) {
+      throw new Error('No sections found in the database');
+    }
+
+    await use(sections);
+  },
+
+  requiredFilter: async ({ testManager }, use) => {
+    const filter = await testManager.dataSource
+      .getRepository(PageFilter)
+      .findOne({ where: { name: 'sector' } });
+
+    if (!filter) {
+      throw new Error('Missing filter with name "sector"');
+    }
+
+    await use(filter);
+  },
+});
+
+test.describe.configure({ mode: 'serial' });
 
 test.describe('Explore E2E', () => {
-  let testManager: E2eTestManager
-  let page: Page
-  let sections: Section[]
+  test.describe('Section Navigation', () => {
+    test('List all sections as anchor links and section elements', async ({
+      page,
+      sections,
+    }) => {
+      const count = sections.length;
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage()
-    testManager = await E2eTestManager.load(page)
-  })
+      await page.goto('/explore');
+      await expect(
+        page.locator('#sidebar-sections-list').locator('a'),
+      ).toHaveCount(count);
+      await expect(
+        page.locator('#in-page-sections-list').locator('a'),
+      ).toHaveCount(count);
+      await expect(
+        page.locator('#sections-container').locator('section'),
+      ).toHaveCount(count);
+    });
 
-  test.beforeEach(async () => {
-    await testManager.clearDatabase()
+    test('Should scroll to the correct section when clicking anchor links', async ({
+      page,
+    }) => {
+      await page.goto('/explore');
+      const sections = await page
+        .locator('#sidebar-sections-list')
+        .locator('a')
+        .all();
 
-    const entityMocks = testManager.mocks()
-    sections = [
-      await entityMocks.createSection({
-        slug: 'section-1',
-        name: 'Section 1',
-        description: ':)',
-        // TODO: We should test the content of the sections including overview section and the widgets
-        // when API is returning widget data in test environment.
-        order: 2,
-        baseWidgets: []
-      }),
-      await entityMocks.createSection({
-        slug: 'section-2',
-        name: 'Section 2',
-        description: ':)',
-        order: 3,
-        baseWidgets: []
-      })
-    ]
-  })
+      for (const link of sections) {
+        const href = await link.getAttribute('href');
+        const targetSectionId = href?.replace('#', '');
 
-  test.afterEach(async () => {
-    await testManager.clearDatabase()
-  })
+        await link.click();
+        await expect(page).toHaveURL(new RegExp(`${href}$`));
 
-  test.afterAll(async () => {
-    await testManager.close()
-  })
+        const targetSection = page.locator(`#${targetSectionId}`);
+        await expect(targetSection).toBeInViewport();
+      }
+    });
 
-  test('List all sections in the sidebar and main body', async () => {
-    await page.goto('/explore')
-    await expect(page.locator('#sections-container').locator('section')).toHaveCount(
-      sections.length
-    )
-    await expect(page.locator('#sidebar-sections-list').locator('a')).toHaveCount(sections.length)
-  })
-})
+    test('Should handle direct anchor navigation and browser history', async ({
+      page,
+      sections,
+    }) => {
+      const lastSection = sections[sections.length - 1];
+
+      // Direct URL navigation
+      await page.goto(`/explore#${lastSection.slug}`);
+
+      const targetSection = page.locator(`#${lastSection.slug}`);
+      await expect(targetSection).toBeInViewport();
+
+      await page.goto('/explore');
+
+      // Test in-page anchor link
+      const links = await page
+        .locator('#in-page-sections-list')
+        .locator('a')
+        .all();
+      const lastLink = links[links.length - 1];
+
+      const lastLinkHref = await lastLink.getAttribute('href');
+      const lastLinkTargetId = lastLinkHref?.replace('#', '');
+
+      await lastLink.click();
+
+      await expect(page).toHaveURL(new RegExp(`${lastLinkHref}$`));
+      const lastLinkTarget = page.locator(`#${lastLinkTargetId}`);
+      await expect(lastLinkTarget).toBeInViewport();
+
+      await page.goBack();
+      await expect(page).not.toHaveURL(new RegExp(`${lastLinkHref}$`));
+
+      await page.goForward();
+      await expect(page).toHaveURL(new RegExp(`${lastLinkHref}$`));
+      await expect(lastLinkTarget).toBeInViewport();
+    });
+  });
+
+  // TODO: Does currently not work + have to update filter select component
+  // test.describe('Section filters', () => {
+  //   test('Should apply filtering when a filter is selected', async ({
+  //     page,
+  //     requiredFilter,
+  //   }) => {
+  //     await page.goto('/explore');
+
+  //     await page.getByRole('button', { name: 'Filters' }).click();
+  //     await page.getByRole('button', { name: 'Add a custom filter' }).click();
+  //     await page.getByRole('button', { name: requiredFilter.name }).click();
+
+  //     await page.getByRole('button', { name: /Select values/i }).click();
+  //     await page
+  //       .getByRole('checkbox', { name: requiredFilter.values[0] })
+  //       .click();
+  //     await page.getByRole('button', { name: 'Apply' }).click();
+  //   });
+  // });
+});

--- a/shared/lib/e2e-test-manager.ts
+++ b/shared/lib/e2e-test-manager.ts
@@ -58,6 +58,26 @@ export class E2eTestManager {
     return createUser(this.dataSource, additionalData);
   }
 
+  async deleteUserById(id: string) {
+    try {
+      await this.dataSource.getRepository(User).delete({
+        id,
+      });
+    } catch (error) {
+      throw new Error(`Failed to delete test user with id: ${id}`);
+    }
+  }
+
+  async deleteUserByEmail(email: string) {
+    try {
+      await this.dataSource.getRepository(User).delete({
+        email,
+      });
+    } catch (error) {
+      throw new Error(`Failed to delete test user with email: ${email}`);
+    }
+  }
+
   mocks() {
     return {
       createUser: (additionalData?: Partial<User>) =>


### PR DESCRIPTION
## Refactor E2E tests to support production-like database state

### Overview

Updates E2E test approach to run against existing database state instead of clearing it. Test data is now created and cleaned up individually, better mimicking real-world scenarios.

Changes:
- Removed database clearing hooks
- Add targeted cleanup for test-specific data
- Maintain existing database state during tests
- Small refactor accessibility section navigation (frontend)

