### PR TITLE
chore(infrastructure): Remove deploy.yaml jop step timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,4 +216,3 @@ jobs:
           version_label: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           deployment_package: infrastructure/source_bundle/deploy.zip
           wait_for_deployment: true
-        timeout-minutes: 2


### PR DESCRIPTION
This pull request includes a small change to the `jobs` section in the `.github/workflows/deploy.yml` file. The change removes the `timeout-minutes` parameter.
