### PR TITLE
Conditionally disable visualization selector in sandbox

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-separator": "1.0.3",
     "@radix-ui/react-slot": "1.0.2",
     "@radix-ui/react-toast": "1.2.1",
+    "@radix-ui/react-tooltip": "1.1.3",
     "@t3-oss/env-nextjs": "0.10.1",
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-table": "8.19.2",

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/client/src/containers/sidebar/index.tsx
+++ b/client/src/containers/sidebar/index.tsx
@@ -74,8 +74,8 @@ const Sidebar: FC = () => {
             <AccordionItem value="sandbox-settings">
               <AccordionTrigger>Settings</AccordionTrigger>
               <AccordionContent className="py-3.5">
-                <VisualizationSelector />
                 <IndicatorSelector />
+                <VisualizationSelector />
               </AccordionContent>
             </AccordionItem>
             <AccordionItem value="sandbox-filters">

--- a/client/src/containers/sidebar/indicator-seletor/index.tsx
+++ b/client/src/containers/sidebar/indicator-seletor/index.tsx
@@ -59,7 +59,9 @@ const IndicatorSelector: FC = () => {
         className={SIDEBAR_POPOVER_CLASS}
       >
         <SearchableList
-          items={widgets}
+          items={widgets.filter((w) =>
+            w.visualisations.every((v) => v !== "single_value"),
+          )}
           itemKey="indicator"
           onItemClick={(w) => {
             if (

--- a/client/src/containers/sidebar/visualization-selector/index.tsx
+++ b/client/src/containers/sidebar/visualization-selector/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, Fragment, useState } from "react";
 
 import {
   WidgetVisualizationsType,
@@ -16,6 +16,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+  Tooltip,
+} from "@/components/ui/tooltip";
 import { SIDEBAR_POPOVER_CLASS } from "@/constants";
 
 const getVisualizationText = (value: WidgetVisualizationsType): string =>
@@ -32,6 +38,26 @@ const VisualizationSelector: FC = () => {
   const { indicator, visualization, setVisualization, widget } =
     useSandboxWidget();
 
+  if (!indicator) {
+    return (
+      <TooltipProvider>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal text-slate-400">
+            Type
+          </TooltipTrigger>
+          <TooltipContent
+            align="start"
+            alignOffset={16}
+            sideOffset={-8}
+            className="rounded-lg border-none px-2 py-1 text-2xs"
+          >
+            <p>Select an indicator first.</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
   return (
     <Popover
       open={showVisualizations}
@@ -44,7 +70,6 @@ const VisualizationSelector: FC = () => {
         <Button
           variant="clean"
           className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary"
-          disabled={!indicator}
         >
           <span>Type</span>
           {visualization && (
@@ -61,24 +86,51 @@ const VisualizationSelector: FC = () => {
         align="start"
         side="bottom"
         className={SIDEBAR_POPOVER_CLASS}
+        onOpenAutoFocus={(event) => {
+          // This prevents the tooltip to automatically trigger
+          event.preventDefault();
+        }}
       >
         <div className="flex h-full flex-col overflow-y-auto">
           {VALID_WIDGET_VISUALIZATIONS.filter(
             (v) => v !== "filter" && v !== "navigation" && v !== "single_value",
           ).map((v) => (
-            <Button
-              key={`v-list-item-${v}`}
-              variant="clean"
-              className="h-10 cursor-pointer justify-start rounded-none px-3 py-4 text-xs font-medium transition-colors hover:bg-slate-100"
-              onClick={() => {
-                setVisualization(v);
-                setShowVisualizations(false);
-                setShowOverlay(false);
-              }}
-              disabled={!widget?.visualisations.includes(v)}
-            >
-              {getVisualizationText(v)}
-            </Button>
+            <Fragment key={`v-list-item-${v}`}>
+              {!widget?.visualisations.includes(v) ? (
+                <TooltipProvider>
+                  <Tooltip delayDuration={300}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        className="h-10 cursor-pointer justify-start rounded-none px-3 py-4 text-xs font-medium text-slate-400"
+                        variant="clean"
+                      >
+                        {getVisualizationText(v)}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      align="start"
+                      alignOffset={16}
+                      sideOffset={-8}
+                      className="rounded-lg border-none bg-popover-foreground px-2 py-1 text-2xs text-white"
+                    >
+                      <p>Not available for the current indicator.</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                <Button
+                  variant="clean"
+                  className="h-10 cursor-pointer justify-start rounded-none px-3 py-4 text-xs font-medium transition-colors hover:bg-slate-100"
+                  onClick={() => {
+                    setVisualization(v);
+                    setShowVisualizations(false);
+                    setShowOverlay(false);
+                  }}
+                >
+                  {getVisualizationText(v)}
+                </Button>
+              )}
+            </Fragment>
           ))}
         </div>
       </PopoverContent>

--- a/client/src/containers/sidebar/visualization-selector/index.tsx
+++ b/client/src/containers/sidebar/visualization-selector/index.tsx
@@ -29,7 +29,8 @@ const getVisualizationText = (value: WidgetVisualizationsType): string =>
 const VisualizationSelector: FC = () => {
   const [showVisualizations, setShowVisualizations] = useState(false);
   const setShowOverlay = useSetAtom(showOverlayAtom);
-  const { visualization, setVisualization } = useSandboxWidget();
+  const { indicator, visualization, setVisualization, widget } =
+    useSandboxWidget();
 
   return (
     <Popover
@@ -43,6 +44,7 @@ const VisualizationSelector: FC = () => {
         <Button
           variant="clean"
           className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary"
+          disabled={!indicator}
         >
           <span>Type</span>
           {visualization && (
@@ -62,7 +64,7 @@ const VisualizationSelector: FC = () => {
       >
         <div className="flex h-full flex-col overflow-y-auto">
           {VALID_WIDGET_VISUALIZATIONS.filter(
-            (v) => v !== "filter" && v !== "navigation",
+            (v) => v !== "filter" && v !== "navigation" && v !== "single_value",
           ).map((v) => (
             <Button
               key={`v-list-item-${v}`}
@@ -73,6 +75,7 @@ const VisualizationSelector: FC = () => {
                 setShowVisualizations(false);
                 setShowOverlay(false);
               }}
+              disabled={!widget?.visualisations.includes(v)}
             >
               {getVisualizationText(v)}
             </Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: 1.2.1
         version: 1.2.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: 1.1.3
+        version: 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@t3-oss/env-nextjs':
         specifier: 0.10.1
         version: 0.10.1(typescript@5.4.5)(zod@3.23.8)
@@ -1580,6 +1583,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.1':
+    resolution: {integrity: sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.0.1':
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
     peerDependencies:
@@ -1709,6 +1725,19 @@ packages:
 
   '@radix-ui/react-portal@1.1.1':
     resolution: {integrity: sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.2':
+    resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1870,6 +1899,19 @@ packages:
 
   '@radix-ui/react-toast@1.2.1':
     resolution: {integrity: sha512-5trl7piMXcZiCq7MW6r8YYmu0bK5qDpTWz+FdEPdKyft2UixkspheYbjbrLXVN5NGKHFbOP7lm8eD0biiSqZqg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.1.3':
+    resolution: {integrity: sha512-Z4w1FIS0BqVFI2c1jZvb/uDVJijJjJ2ZMuPV81oVgTZ7g3BZxobplnMVvXtFWgtozdvYJ+MFWtwkM5S2HnAong==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8131,6 +8173,19 @@ snapshots:
       '@types/react': 18.3.2
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-dismissable-layer@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-focus-guards@1.0.1(@types/react@18.3.2)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.24.5
@@ -8264,6 +8319,16 @@ snapshots:
       '@types/react-dom': 18.3.0
 
   '@radix-ui/react-portal@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-portal@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.2)(react@18.3.1)
@@ -8442,6 +8507,26 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.2
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-tooltip@1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.2)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.2)(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
# Conditionally disable visualization selector in sandbox

- Force user to select indicator first by disabling the visualization selector
- Disable visualization selection from list if combination is not possible
- Removed "single value" from visualization selection

[Figma flow](https://www.figma.com/proto/1MQAbB99h05eR5xbHqNDVn/4Growth-%5BInternal%5D?page-id=3103%3A1244&node-id=6842-15645&node-type=frame&viewport=-13771%2C1965%2C1&t=Nspde3dObHoE7E0h-9&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=6842%3A15645&show-proto-sidebar=1)
[Figma design](https://www.figma.com/design/1MQAbB99h05eR5xbHqNDVn/4Growth-%5BInternal%5D?node-id=6842-15645&t=5p9hCakvz2VRuP7w-4)