### PR TITLE
Fix/pre demo fixes

### DIFF
--- a/api/test/e2e/users/custom-widgets/custom-widget-crud.spec.ts
+++ b/api/test/e2e/users/custom-widgets/custom-widget-crud.spec.ts
@@ -127,24 +127,6 @@ describe('Custom Widgets API', () => {
   });
 
   describe('Read API', () => {
-    it("Shouldn't allow anonymous users to read custom widgets", async () => {
-      // Given
-      await entityMocks.createCustomWidget({
-        name: 'custom-widget',
-        user: { id: testUser.id },
-        widget: { indicator: baseWidget.indicator },
-      });
-
-      // When
-      const res = await testManager
-        .request()
-        .get(`/users/${VALID_UUID}/widgets`);
-
-      // Then
-      expect(res.status).toBe(401);
-      expect(res.body.errors).toBeDefined();
-    });
-
     it('Should allow authenticated users to read their custom widgets', async () => {
       // Given
       await entityMocks.createCustomWidget({
@@ -282,6 +264,73 @@ describe('Custom Widgets API', () => {
 
       // Then
       expect(res.status).toBe(403);
+      expect(res.body.errors).toBeDefined();
+    });
+
+    it("Shouldn't allow authenticated users to read other user's custom widgets by id", async () => {
+      // Given
+      // Other user's custom widgets
+      const { user: otherUser } = await testManager.setUpTestUser({
+        email: '2@test.com',
+      });
+      const createdCustomWidget = await entityMocks.createCustomWidget({
+        name: 'other-user-custom-widget1',
+        user: { id: otherUser.id },
+        widget: { indicator: baseWidget.indicator },
+      });
+
+      // When
+      const res = await testManager
+        .request()
+        .get(`/users/${otherUser.id}/widgets/${createdCustomWidget.id}`)
+        .set('Authorization', `Bearer ${authToken}`);
+
+      // Then
+      expect(res.status).toBe(403);
+      expect(res.body.errors).toBeDefined();
+    });
+
+    it("Shouldn't allow anonymous users to read other user's custom widgets", async () => {
+      // Given
+      // Other user's custom widgets
+      const { user: otherUser } = await testManager.setUpTestUser({
+        email: '2@test.com',
+      });
+      await entityMocks.createCustomWidget({
+        name: 'other-user-custom-widget1',
+        user: { id: otherUser.id },
+        widget: { indicator: baseWidget.indicator },
+      });
+
+      // When
+      const res = await testManager
+        .request()
+        .get(`/users/${otherUser.id}/widgets`);
+
+      // Then
+      expect(res.status).toBe(401);
+      expect(res.body.errors).toBeDefined();
+    });
+
+    it("Shouldn't allow anonymous users to read other user's custom widgets by id", async () => {
+      // Given
+      // Other user's custom widgets
+      const { user: otherUser } = await testManager.setUpTestUser({
+        email: '2@test.com',
+      });
+      const createdCustomWidget = await entityMocks.createCustomWidget({
+        name: 'other-user-custom-widget1',
+        user: { id: otherUser.id },
+        widget: { indicator: baseWidget.indicator },
+      });
+
+      // When
+      const res = await testManager
+        .request()
+        .get(`/users/${otherUser.id}/widgets/${createdCustomWidget.id}`);
+
+      // Then
+      expect(res.status).toBe(401);
       expect(res.body.errors).toBeDefined();
     });
   });

--- a/shared/contracts/users.contract.ts
+++ b/shared/contracts/users.contract.ts
@@ -126,7 +126,8 @@ export const usersContract = contract.router({
     query: generateEntityQuerySchema(CustomWidget),
     responses: {
       200: contract.type<ApiPaginationResponse<CustomWidget>>(),
-      400: contract.type<JSONAPIError>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
       404: contract.type<JSONAPIError>(),
       500: contract.type<JSONAPIError>(),
     },
@@ -138,6 +139,8 @@ export const usersContract = contract.router({
     responses: {
       200: contract.type<ApiResponse<CustomWidget>>(),
       400: contract.type<JSONAPIError>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
       404: contract.type<JSONAPIError>(),
       500: contract.type<JSONAPIError>(),
     },


### PR DESCRIPTION
This pull request includes significant changes to the `PostgresSurveyAnswerRepository`, improvements to the test coverage for custom widgets, and updates to the `usersContract` to handle additional error responses. The key changes are detailed below.

### Repository Updates:
* Refactored the query logic in the `PostgresSurveyAnswerRepository` to improve parameter handling and SQL query structure. (`api/src/infrastructure/postgres-survey-answers.repository.ts`)

### Test Coverage Enhancements:
* Removed a test for anonymous users attempting to read custom widgets and added multiple new tests to cover various scenarios for reading custom widgets, including checks for authenticated and anonymous users. (`api/test/e2e/users/custom-widgets/custom-widget-crud.spec.ts`) [[1]](diffhunk://#diff-d478baa11587725bc5d3ebb033c23ebcd9a9b0af706400081ff7fbc670088113L130-L147) [[2]](diffhunk://#diff-d478baa11587725bc5d3ebb033c23ebcd9a9b0af706400081ff7fbc670088113R269-R335)
* Updated the test for retrieving a widget with its filtered data by its id to use parameterized tests, improving test coverage and maintainability. (`api/test/e2e/widgets/base-widgets.spec.ts`)

### Contract Updates:
* Added `401` and `403` error responses to the `usersContract` to handle unauthorized and forbidden access attempts. (`shared/contracts/users.contract.ts`) [[1]](diffhunk://#diff-9aa2731a3c9ddbbe326ef0bf2dc4d7584fcadd538036381ce548eede4b2f1a9dL129-R130) [[2]](diffhunk://#diff-9aa2731a3c9ddbbe326ef0bf2dc4d7584fcadd538036381ce548eede4b2f1a9dR142-R143)