### PR TITLE
FE - add a way to go back to the sandbox from the profile screen

### DIFF
--- a/client/src/containers/header/index.tsx
+++ b/client/src/containers/header/index.tsx
@@ -19,7 +19,7 @@ const Header: FC = () => {
 
   return (
     <header className="flex items-center justify-between rounded-2xl bg-accent p-4">
-      <Link href="/sandbox">
+      <Link href="/explore">
         <div className="h-[72px] w-[160px] space-y-3 bg-logo bg-no-repeat">
           <h1 className="overflow-hidden whitespace-nowrap indent-[100%]">
             4Growth Visualisation Platform

--- a/client/src/containers/header/index.tsx
+++ b/client/src/containers/header/index.tsx
@@ -12,17 +12,20 @@ import {
 } from "@/components/ui/popover";
 
 import Menu from "./menu";
+import Link from "next/link";
 
 const Header: FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <header className="flex items-center justify-between rounded-2xl bg-accent p-4">
-      <div className="h-[72px] w-[160px] space-y-3 bg-logo bg-no-repeat">
-        <h1 className="overflow-hidden whitespace-nowrap indent-[100%]">
-          4Growth Visualisation Platform
-        </h1>
-      </div>
+      <Link href="/sandbox">
+        <div className="h-[72px] w-[160px] space-y-3 bg-logo bg-no-repeat">
+          <h1 className="overflow-hidden whitespace-nowrap indent-[100%]">
+            4Growth Visualisation Platform
+          </h1>
+        </div>
+      </Link>
 
       {isOpen && <Overlay />}
 

--- a/client/src/containers/header/menu/index.tsx
+++ b/client/src/containers/header/menu/index.tsx
@@ -3,12 +3,16 @@ import { FC } from "react";
 import Link from "next/link";
 
 import UserMenu from "./user";
+import { usePathname } from "next/navigation";
 
 export const classes = {
   link: "block px-4 py-2 hover:bg-muted transition-colors",
 };
 
 const Menu: FC = () => {
+  const pathname = usePathname();
+  const showLinks = !/^\/(?:explore|sandbox)/.test(pathname);
+
   return (
     <nav className="min-w-[150px]">
       <ul className="overflow-hidden py-2">
@@ -23,6 +27,20 @@ const Menu: FC = () => {
             4Growth project site
           </a>
         </li>
+        {showLinks && (
+          <>
+            <li>
+              <Link href="/" className={classes.link}>
+                Explore
+              </Link>
+            </li>
+            <li>
+              <Link href="/sandbox" className={classes.link}>
+                Sandbox
+              </Link>
+            </li>
+          </>
+        )}
         <li>
           <Link href="/about" className={classes.link}>
             About


### PR DESCRIPTION
## FE - add a way to go back to the sandbox from the profile screen

### Overview

- Redirect to sandbox page when clicking on "4Growth Visualization Platform" logo
- Display links to /explore and /sandbox when not on 1 of these pages

### Feature relevant tickets

[SIRH-194](https://vizzuality.atlassian.net/browse/SIRH-194)



[SIRH-194]: https://vizzuality.atlassian.net/browse/SIRH-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ