### PR TITLE
show vertical bar chart in projections page

### DIFF
--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { getRouteHref } from "@/utils/route-config";
+import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 
 const getMenuButtonText = (v: ProjectionVisualizationsType): string => {
   switch (v) {
@@ -125,6 +126,12 @@ export default function Widget({
   switch (selectedVisualization) {
     case "area_chart":
     case "bar_chart":
+      return (
+        <Card className={cn("relative p-0", showOverlay && "z-50", className)}>
+          <WidgetHeader indicator={indicator} menu={menuComponent} />
+          <VerticalBarChart indicator={indicator} data={data} />
+        </Card>
+      );
     case "bubble_chart":
     case "line_chart":
       return (

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -13,13 +13,13 @@ import { cn } from "@/lib/utils";
 import MenuButton from "@/containers/menu-button";
 import NoData from "@/containers/no-data";
 import { showOverlayAtom } from "@/containers/overlay/store";
+import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 import WidgetHeader from "@/containers/widget/widget-header";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { getRouteHref } from "@/utils/route-config";
-import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 
 const getMenuButtonText = (v: ProjectionVisualizationsType): string => {
   switch (v) {

--- a/client/src/containers/widget/vertical-bar-chart/index.tsx
+++ b/client/src/containers/widget/vertical-bar-chart/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { FC, useRef, useEffect, useState } from "react";
 
-import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, Cell, XAxis } from "recharts";
 
 import NoData from "@/containers/no-data";
 import { getIndexOfLargestValue } from "@/containers/widget/utils";

--- a/client/src/containers/widget/vertical-bar-chart/index.tsx
+++ b/client/src/containers/widget/vertical-bar-chart/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { FC, useRef, useEffect, useState } from "react";
 
-import { Bar, BarChart, Cell, XAxis } from "recharts";
+import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import NoData from "@/containers/no-data";
 import { getIndexOfLargestValue } from "@/containers/widget/utils";
@@ -18,11 +18,14 @@ type ProjectionsData = Array<{
   value: number;
 }>;
 interface VerticalBarChartProps {
-  title: string;
+  indicator: string;
   data?: ProjectionsData;
 }
 
-const VerticalBarChart: FC<VerticalBarChartProps> = ({ title, data }) => {
+// BAR_GAP is explicitly set to compensate for the default spacing at chart edges
+// This ensures consistent bar spacing across the entire chart width
+const BAR_GAP = 2;
+const VerticalBarChart: FC<VerticalBarChartProps> = ({ indicator, data }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const [tickMargin, setTickMargin] = useState<number>(0);
 
@@ -54,14 +57,17 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({ title, data }) => {
   return (
     <ChartContainer
       config={{}}
-      className="w-full p-0 [&_.recharts-cartesian-axis-tick_text]:fill-foreground [&_.recharts-cartesian-axis-tick_text]:font-medium"
+      // The XAxis component adds default height to the chart container
+      // We use negative margin to compensate and keep the chart compact
+      // See: https://recharts.org/en-US/api/XAxis#height
+      className="-mb-[30px] [&_.recharts-cartesian-axis-tick_text]:fill-foreground [&_.recharts-cartesian-axis-tick_text]:font-medium"
       ref={chartRef}
     >
       <BarChart
-        margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
+        margin={{ top: 0, left: -BAR_GAP, right: -BAR_GAP, bottom: 0 }}
         data={data}
         layout="horizontal"
-        barGap={2}
+        barCategoryGap={BAR_GAP}
         accessibilityLayer
       >
         <ChartTooltip
@@ -74,7 +80,7 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({ title, data }) => {
                 <div className="flex gap-2">
                   <p className="flex flex-col items-end justify-end gap-2">
                     <span>Year</span>
-                    <span>{title}</span>
+                    <span>{indicator}</span>
                   </p>
                   <p className="flex flex-col gap-2">
                     <span className="font-bold">{payload[0].payload.year}</span>
@@ -93,8 +99,8 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({ title, data }) => {
               index: number,
               total: number,
             ): [number, number, number, number] => {
-              if (index === 0) return [8, 8, 0, 50];
-              if (index === total - 1) return [8, 8, 50, 0];
+              if (index === 0) return [8, 8, 0, 16];
+              if (index === total - 1) return [8, 8, 16, 0];
               return [8, 8, 0, 0];
             };
 

--- a/client/tests/widget/vertical-bar-chart.test.tsx
+++ b/client/tests/widget/vertical-bar-chart.test.tsx
@@ -27,7 +27,7 @@ vi.mock("@/containers/no-data", () => ({
 
 describe("VerticalBarChart", () => {
   const mockProps = {
-    title: "Market potential",
+    indicator: "Market potential",
     data: [
       { year: 2020, value: 100 },
       { year: 2021, value: 50 },
@@ -63,7 +63,7 @@ describe("VerticalBarChart", () => {
           const tooltip = within(tooltipWrapper);
           expect(tooltip.getByText("Year")).toBeTruthy();
           expect(tooltip.getByText(mockProps.data[0].year)).toBeTruthy();
-          expect(tooltip.getByText(mockProps.title)).toBeTruthy();
+          expect(tooltip.getByText(mockProps.indicator)).toBeTruthy();
           expect(tooltip.getByText(mockProps.data[0].value)).toBeTruthy();
         } else {
           throw new Error("Unable to trigger tooltip in VerticalBarChart");


### PR DESCRIPTION
## show vertical bar chart in projections page

### Changes
- Implemented vertical bar chart visualization for projections widget
- Added proper chart layout and styling with consistent bar spacing
- Improved chart margins and axis configuration
- Updated component props to use `indicator` instead of `title`