### PR TITLE
client: remove N/A labels for widgets data

### DIFF
--- a/client/src/containers/explore/survey-analysis/index.tsx
+++ b/client/src/containers/explore/survey-analysis/index.tsx
@@ -20,8 +20,8 @@ import OverviewSection from "@/containers/explore/section/overview-section";
 import { intersectingAtom } from "@/containers/explore/store";
 import Widget from "@/containers/widget/survey-analysis";
 
-import { useScrollSpy } from "tests/hooks/use-scroll-spy";
 import { TransformedWidget, TransformedWidgetData } from "@/types";
+import { useScrollSpy } from "tests/hooks/use-scroll-spy";
 
 export default function Explore() {
   const { filters } = useFilters();

--- a/client/src/containers/widget/survey-analysis/index.tsx
+++ b/client/src/containers/widget/survey-analysis/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@shared/dto/widgets/widget-visualizations.constants";
 import { useAtom } from "jotai";
 
+import { removeNaLabels } from "@/lib/normalize-widget-data";
 import { cn, isEmptyWidget } from "@/lib/utils";
 
 import MenuButton from "@/containers/menu-button";
@@ -28,8 +29,8 @@ import WidgetHeader from "@/containers/widget/widget-header";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { getRouteHref } from "@/utils/route-config";
 import { TransformedWidgetData } from "@/types";
+import { getRouteHref } from "@/utils/route-config";
 
 const getMenuButtonText = (v: WidgetVisualizationsType): string => {
   switch (v) {
@@ -186,7 +187,7 @@ export default function Widget({
             responseRate={responseRate}
           />
           <HorizontalBarChart
-            data={data.raw.chart}
+            data={removeNaLabels(data.raw.chart)}
             {...config?.horizontalBarChart}
           />
         </Card>

--- a/client/src/lib/normalize-widget-data.ts
+++ b/client/src/lib/normalize-widget-data.ts
@@ -78,15 +78,24 @@ function calculateTotalWithoutNA(chartData: WidgetChartData): number {
 function normalizeChartData(chartData: WidgetChartData): WidgetChartData {
   const totalWithoutNA = calculateTotalWithoutNA(chartData);
 
-  return chartData
-    .map((entry) => ({
+  return removeNaLabels(
+    chartData.map((entry) => ({
       ...entry,
       value: calculatePercentage(
         entry.value,
         totalWithoutNA === 0 ? entry.total : totalWithoutNA,
       ),
-    }))
-    .filter((c) => c.label !== "N/A");
+    })),
+  );
+}
+
+/**
+ * Filters out entries with "N/A" labels from chart data
+ * @param data - The chart data to filter
+ * @returns Filtered chart data without N/A entries
+ */
+function removeNaLabels(data?: WidgetChartData): WidgetChartData {
+  return data?.filter((c) => c.label !== "N/A") || [];
 }
 
 /**
@@ -104,4 +113,4 @@ function calculatePercentage(value: number, total: number): number {
   return Math.round(percentage);
 }
 
-export { normalizeWidgetData, getResponseRate };
+export { normalizeWidgetData, getResponseRate, removeNaLabels };

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -76,7 +76,7 @@ export function formatNumber(
   value: number,
   options: Intl.NumberFormatOptions = {},
 ) {
-  return new Intl.NumberFormat("en-DE", {
+  return new Intl.NumberFormat("en-GB", {
     style: "decimal",
     maximumFractionDigits: 2,
     minimumFractionDigits: 0,


### PR DESCRIPTION
## remove N/A labels for widgets data

## Changes
- Extract `removeNaLabels` function to handle N/A entries in chart data
- Apply N/A label filtering to horizontal bar chart data
- Update number formatting locale from 'en-DE' to 'en-GB'
- Minor code organization improvements (import ordering)