### PR TITLE
add basic and custom filters to projections explore page

### DIFF
--- a/client/src/app/(root)/projections/layout.tsx
+++ b/client/src/app/(root)/projections/layout.tsx
@@ -22,6 +22,11 @@ export default async function ProjectionsLayout({
     queryFn: async () =>
       client.projections.getProjectionsWidgets.query(QUERY_OPTIONS),
   });
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.projections.filters.queryKey,
+    queryFn: async () =>
+      client.projections.getProjectionsFilters.query(QUERY_OPTIONS),
+  });
 
   return (
     <Hydrate state={dehydrate(queryClient)}>

--- a/client/src/containers/sidebar/filter-settings/clear-filters-button/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/clear-filters-button/index.tsx
@@ -7,16 +7,17 @@ import useFilters from "@/hooks/use-filters";
 import { Button } from "@/components/ui/button";
 
 const ClearFiltersButton: FC = () => {
-  const { filters, setFilters } = useFilters();
+  const { filters, removeAllExceptScenario } = useFilters();
+  const hasOnlyScenarioFilters = filters.every((f) => f.name === "scenario");
 
-  if (filters.length === 0) return null;
+  if (filters.length === 0 || hasOnlyScenarioFilters) return null;
 
   return (
     <Button
       type="button"
       variant="clean"
       className="absolute right-14 top-0 h-auto translate-y-1/2 gap-1 p-0 text-xs font-normal transition-colors hover:text-white/80"
-      onClick={() => setFilters([])}
+      onClick={removeAllExceptScenario}
     >
       <span>Clear all</span>
       <Trash2Icon className="h-4 w-4" />

--- a/client/src/containers/sidebar/filter-settings/constants.ts
+++ b/client/src/containers/sidebar/filter-settings/constants.ts
@@ -1,0 +1,42 @@
+export const SURVEY_ANALYSIS_DEFAULT_FILTERS = [
+  "location-country-region",
+  "sector",
+];
+
+export const PROJECTIONS_DEFAULT_FILTERS = [
+  "country",
+  "technology-type",
+  "technology",
+  "application",
+];
+
+export const DEFAULT_FILTERS_LABEL_MAP: Record<
+  string,
+  { selected: string; unSelected: string }
+> = {
+  country: {
+    selected: "Country",
+    unSelected: "All countries",
+  },
+
+  "technology-type": {
+    selected: "Technology type",
+    unSelected: "All technology types",
+  },
+  technology: {
+    selected: "Technology",
+    unSelected: "All technologies",
+  },
+  application: {
+    selected: "Application",
+    unSelected: "All applications",
+  },
+  "location-country-region": {
+    selected: "Country",
+    unSelected: "All countries",
+  },
+  sector: {
+    selected: "Sector",
+    unSelected: "All operation areas",
+  },
+} as const;

--- a/client/src/containers/sidebar/filter-settings/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/index.tsx
@@ -41,27 +41,25 @@ const FilterSettings: FC<FilterSettingsProps> = ({
         enabled: type === "projections",
       },
     );
-  const selectedCustomFilters = filterQueryParams.filter(
-    (f) => !defaultFilters.includes(f.name),
-  );
+  const selectedCustomFilters = filterQueryParams.filter((f) => {
+    if (type === "projections" && f.name === "scenario") return false;
+
+    return !defaultFilters.includes(f.name);
+  });
 
   const allFilters = useMemo(() => {
     if (type === "surveyAnalysis") {
       return surveyAnalysisFiltersQuery.data || [];
     } else {
-      return projectionsFiltersQuery.data || [];
+      return (
+        projectionsFiltersQuery.data?.filter((f) => f.name !== "scenario") || []
+      );
     }
   }, [type, surveyAnalysisFiltersQuery.data, projectionsFiltersQuery.data]);
 
   const customFilters = useMemo(
-    () =>
-      allFilters.filter((f) => {
-        if (type === "projections" && f.name === "scenario") {
-          return false;
-        }
-        return !defaultFilters.includes(f.name);
-      }) || [],
-    [allFilters, defaultFilters, type],
+    () => allFilters.filter((f) => !defaultFilters.includes(f.name)) || [],
+    [allFilters, defaultFilters],
   );
 
   return (

--- a/client/src/containers/sidebar/filter-settings/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/index.tsx
@@ -2,14 +2,13 @@ import { FC, useMemo } from "react";
 
 import { client } from "@/lib/queryClient";
 import { queryKeys } from "@/lib/queryKeys";
-import { CountryISO3Map } from "@shared/constants/country-iso3.map";
+import { normalizeProjectionsFilterValues } from "@/lib/utils";
 
 import { FilterQueryParam } from "@/hooks/use-filters";
 
 import BreakdownSelector from "@/containers/sidebar/breakdown-selector";
 import { DEFAULT_FILTERS_LABEL_MAP } from "@/containers/sidebar/filter-settings/constants";
 import FilterPopup from "@/containers/sidebar/filter-settings/filter-popup";
-import { normalizeProjectionsFilterValues } from "@/lib/utils";
 
 interface FilterSettingsProps {
   type: "projections" | "surveyAnalysis";

--- a/client/src/containers/sidebar/projections-sidebar/explore-sidebar/index.tsx
+++ b/client/src/containers/sidebar/projections-sidebar/explore-sidebar/index.tsx
@@ -4,9 +4,14 @@ import { useSetAtom } from "jotai";
 
 import { showScenarioInfoAtom } from "@/app/(root)/projections/store";
 
+import useFilters from "@/hooks/use-filters";
+
 import ScenariosInfo from "@/containers/scenarios/info";
 import ScenarioInfoButton from "@/containers/scenarios/info-button";
 import ScenariosSelector from "@/containers/scenarios/selector";
+import FilterSettings from "@/containers/sidebar/filter-settings";
+import ClearFiltersButton from "@/containers/sidebar/filter-settings/clear-filters-button";
+import { PROJECTIONS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";
 
 import {
   Accordion,
@@ -18,12 +23,14 @@ import { Button } from "@/components/ui/button";
 
 const ExploreSidebar: FC = () => {
   const setShowScenarioInfo = useSetAtom(showScenarioInfoAtom);
+  const { filters, addFilter, removeFilterValue } = useFilters();
+
   return (
     <Accordion
       key="sidebar-accordion-explore"
       type="multiple"
       className="w-full overflow-y-auto"
-      defaultValue={["scenario"]}
+      defaultValue={["scenario", "filters"]}
     >
       <AccordionItem value="scenario">
         <AccordionTrigger>
@@ -44,6 +51,21 @@ const ExploreSidebar: FC = () => {
         </AccordionTrigger>
         <AccordionContent className="py-3.5">
           <ScenariosSelector />
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="filters">
+        <div className="relative">
+          <AccordionTrigger>Filters</AccordionTrigger>
+          <ClearFiltersButton />
+        </div>
+        <AccordionContent className="py-3.5">
+          <FilterSettings
+            type="projections"
+            defaultFilters={PROJECTIONS_DEFAULT_FILTERS}
+            filterQueryParams={filters}
+            onAddFilter={addFilter}
+            onRemoveFilterValue={removeFilterValue}
+          />
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/client/src/containers/sidebar/survey-analysis-sidebar/explore-sidebar/index.tsx
+++ b/client/src/containers/sidebar/survey-analysis-sidebar/explore-sidebar/index.tsx
@@ -4,6 +4,7 @@ import useFilters from "@/hooks/use-filters";
 
 import FilterSettings from "@/containers/sidebar/filter-settings";
 import ClearFiltersButton from "@/containers/sidebar/filter-settings/clear-filters-button";
+import { SURVEY_ANALYSIS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";
 import SectionsNav from "@/containers/sidebar/sections-nav";
 
 import {
@@ -30,6 +31,8 @@ const ExploreSidebar: FC = () => {
         </div>
         <AccordionContent className="py-3.5">
           <FilterSettings
+            type="surveyAnalysis"
+            defaultFilters={SURVEY_ANALYSIS_DEFAULT_FILTERS}
             filterQueryParams={filters}
             onAddFilter={addFilter}
             onRemoveFilterValue={removeFilterValue}

--- a/client/src/containers/sidebar/survey-analysis-sidebar/sandbox-sidebar/index.tsx
+++ b/client/src/containers/sidebar/survey-analysis-sidebar/sandbox-sidebar/index.tsx
@@ -5,6 +5,7 @@ import useSandboxWidget from "@/hooks/use-sandbox-widget";
 
 import FilterSettings from "@/containers/sidebar/filter-settings";
 import ClearFiltersButton from "@/containers/sidebar/filter-settings/clear-filters-button";
+import { SURVEY_ANALYSIS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";
 import IndicatorSelector from "@/containers/sidebar/indicator-seletor";
 import VisualizationSelector from "@/containers/sidebar/visualization-selector";
 
@@ -54,6 +55,8 @@ const SandboxSidebar: FC = () => {
         </div>
         <AccordionContent className="py-3.5">
           <FilterSettings
+            type="surveyAnalysis"
+            defaultFilters={SURVEY_ANALYSIS_DEFAULT_FILTERS}
             filterQueryParams={filters}
             onAddFilter={addFilter}
             onRemoveFilterValue={removeFilterValue}

--- a/client/src/containers/sidebar/survey-analysis-sidebar/user-sandbox-sidebar/index.tsx
+++ b/client/src/containers/sidebar/survey-analysis-sidebar/user-sandbox-sidebar/index.tsx
@@ -11,6 +11,7 @@ import { FilterQueryParam } from "@/hooks/use-filters";
 
 import FilterSettings from "@/containers/sidebar/filter-settings";
 import ClearFiltersButton from "@/containers/sidebar/filter-settings/clear-filters-button";
+import { SURVEY_ANALYSIS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";
 import IndicatorSelector from "@/containers/sidebar/indicator-seletor";
 import {
   sandboxFiltersAtom,
@@ -93,6 +94,8 @@ const UserSandboxSidebar: FC = () => {
         </div>
         <AccordionContent className="py-3.5">
           <FilterSettings
+            type="surveyAnalysis"
+            defaultFilters={SURVEY_ANALYSIS_DEFAULT_FILTERS}
             filterQueryParams={filters}
             onAddFilter={addFilter}
             onRemoveFilterValue={removeFilterValue}

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -15,6 +15,7 @@ import NoData from "@/containers/no-data";
 import { showOverlayAtom } from "@/containers/overlay/store";
 import AreaChart from "@/containers/widget/area-chart";
 import LineChart from "@/containers/widget/line-chart";
+import TableView from "@/containers/widget/table";
 import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 import WidgetHeader from "@/containers/widget/widget-header";
 
@@ -33,6 +34,8 @@ const getMenuButtonText = (v: ProjectionVisualizationsType): string => {
       return "Show as a bar chart";
     case "bubble_chart":
       return "Show as a bubble chart";
+    case "table":
+      return "Show as a table";
     default:
       return "";
   }
@@ -149,6 +152,13 @@ export default function Widget({
         <Card className={cn("relative p-0", showOverlay && "z-50", className)}>
           <WidgetHeader indicator={indicator} menu={menuComponent} />
           <AreaChart {...widgetComponentProps} />
+        </Card>
+      );
+    case "table":
+      return (
+        <Card className={cn("relative p-0", showOverlay && "z-50", className)}>
+          <WidgetHeader indicator={indicator} menu={menuComponent} />
+          <TableView {...widgetComponentProps} />
         </Card>
       );
     case "bubble_chart":

--- a/client/src/hooks/use-filters.ts
+++ b/client/src/hooks/use-filters.ts
@@ -74,7 +74,18 @@ function useFilters() {
     [filters, setFilters],
   );
 
-  return { filters, setFilters, addFilter, removeFilterValue, removeFilter };
+  const removeAllExceptScenario = useCallback(() => {
+    setFilters(filters.filter((filter) => filter.name === "scenario"));
+  }, [filters, setFilters]);
+
+  return {
+    filters,
+    setFilters,
+    addFilter,
+    removeFilterValue,
+    removeFilter,
+    removeAllExceptScenario,
+  };
 }
 
 const REQUIRED_KEYS = ["name", "operator", "values"];

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -38,6 +38,7 @@ export const projectionsKeys = createQueryKeys("projections", {
   widgets: (dataFilters: FilterQueryParam[]) => ({
     queryKey: [{ dataFilters }],
   }),
+  filters: null,
 });
 
 export const queryKeys = mergeQueryKeys(

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -3,6 +3,8 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 import { FilterQueryParam } from "./../hooks/use-filters";
+import { ProjectionFilter } from "@shared/dto/projections/projection-filter.entity";
+import { CountryISO3Map } from "@shared/constants/country-iso3.map";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -82,4 +84,21 @@ export function formatNumber(
     minimumFractionDigits: 0,
     ...options,
   }).format(value);
+}
+
+export function normalizeProjectionsFilterValues(
+  filters: ProjectionFilter[],
+): ProjectionFilter[] {
+  return filters.map((filter) => {
+    if (filter.name === "country") {
+      return {
+        ...filter,
+        values: filter.values.map(
+          (value: string) =>
+            CountryISO3Map.getCountryNameByISO3(value) || value,
+        ),
+      };
+    }
+    return filter;
+  });
 }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,10 +1,10 @@
+import { CountryISO3Map } from "@shared/constants/country-iso3.map";
+import { ProjectionFilter } from "@shared/dto/projections/projection-filter.entity";
 import { BaseWidgetWithData } from "@shared/dto/widgets/base-widget-data.interface";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 import { FilterQueryParam } from "./../hooks/use-filters";
-import { ProjectionFilter } from "@shared/dto/projections/projection-filter.entity";
-import { CountryISO3Map } from "@shared/constants/country-iso3.map";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));


### PR DESCRIPTION
### add basic and custom filters to projections explore page

### Changes
- **New Filter System**: Added projections-specific filters with dedicated API integration
- **Enhanced Sidebar**: Integrated filter settings into the projections explore sidebar
- **Table View**: Added table visualization option for projections data
- **Filter Normalization**: Implemented country code to name mapping for better UX
- **Code Reorganization**: Extracted filter constants and improved component reusability

### Jira
- [SIRH-200](https://vizzuality.atlassian.net/browse/SIRH-200)


[SIRH-200]: https://vizzuality.atlassian.net/browse/SIRH-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ