### PR TITLE
[SIRH-229] fix(scenarios): At least one scenario must be selected. Set default scenario.

### DIFF
--- a/client/src/containers/scenarios/selector/index.tsx
+++ b/client/src/containers/scenarios/selector/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useLayoutEffect } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -8,6 +8,11 @@ import { SCENARIOS } from "@/containers/scenarios/constants";
 
 const ScenariosSelector: FC = () => {
   const { selectedScenarios, toggleScenario } = useScenarioFilter();
+
+  useLayoutEffect(() => {
+    toggleScenario(SCENARIOS[0].value);
+  }, []);
+
   return (
     <div className="grid grid-cols-2 gap-0.5">
       {SCENARIOS.map((s) => (

--- a/client/src/containers/widget/map/index.tsx
+++ b/client/src/containers/widget/map/index.tsx
@@ -39,11 +39,7 @@ const Map: FC<MapProps> = ({ data }) => {
                 <Geography
                   key={geo.rsmKey}
                   geography={geo}
-                  stroke={
-                    geo.properties.CONTINENT === "Europe"
-                      ? "hsl(var(--background))"
-                      : "rgb(29 39 87 / var(--tw-bg-opacity))"
-                  }
+                  stroke={"rgb(29 39 87 / var(--tw-bg-opacity))"}
                   strokeWidth="1.0"
                   className={cn(
                     "fill-map- focus:outline-none",

--- a/client/src/hooks/use-scenario-filter.ts
+++ b/client/src/hooks/use-scenario-filter.ts
@@ -14,9 +14,7 @@ export default function useScenarioFilter() {
 
   const toggleScenario = useCallback(
     (value: string) => {
-      if (selectedScenarios.includes(value)) {
-        removeFilter("scenario");
-      } else {
+      if (!selectedScenarios.includes(value)) {
         addFilter({ name: "scenario", operator: "=", values: [value] });
       }
     },


### PR DESCRIPTION
This pull request introduces changes to the `ScenariosSelector` component and the `useScenarioFilter` hook to improve default behavior and streamline scenario selection logic. The most important changes include adding a `useLayoutEffect` to set a default scenario on mount and simplifying the `toggleScenario` function to only add scenarios if they are not already selected.

### Component Enhancements:
* [`client/src/containers/scenarios/selector/index.tsx`](diffhunk://#diff-b5d6e546c2d8e00dac0f2c26df77ef21b1930da6aec859be75dc4e752b7b7b40R11-R15): Added `useLayoutEffect` to automatically select the first scenario (`SCENARIOS[0].value`) when the `ScenariosSelector` component mounts. This ensures a default scenario is always selected.

### Logic Simplification:
* [`client/src/hooks/use-scenario-filter.ts`](diffhunk://#diff-fa49c30f6e14d31022a8b6e6073846224633506df9fe0738d78e64767f393a7fL17-R17): Simplified the `toggleScenario` function to only add a scenario if it isn't already selected, removing the logic for deselecting scenarios.