### PR TITLE
fix: Remove "table" for the avilable visualizations for projections

### DIFF
--- a/shared/dto/projections/projection-visualizations.constants.ts
+++ b/shared/dto/projections/projection-visualizations.constants.ts
@@ -8,7 +8,7 @@ export const PROJECTION_VISUALIZATIONS = {
 
 export const AVAILABLE_PROJECTION_VISUALIZATIONS = Object.values(
   PROJECTION_VISUALIZATIONS,
-);
+).filter((value) => value !== PROJECTION_VISUALIZATIONS.TABLE);
 
 export type ProjectionVisualizationsType =
   (typeof PROJECTION_VISUALIZATIONS)[keyof typeof PROJECTION_VISUALIZATIONS];


### PR DESCRIPTION
This pull request makes a small change to the `AVAILABLE_PROJECTION_VISUALIZATIONS` constant in `projection-visualizations.constants.ts`, ensuring that the `TABLE` visualization is excluded from the available visualizations.

* Excluded `PROJECTION_VISUALIZATIONS.TABLE` from the `AVAILABLE_PROJECTION_VISUALIZATIONS` array by filtering it out.