### PR TITLE
Fix projections

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -3,7 +3,10 @@ import { Logger, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { ProjectionData } from '@shared/dto/projections/projection-data.entity';
 import { IProjectionDataRepository } from '@api/infrastructure/projection-data-repository.interface';
-import { SearchFilterDTO } from '@shared/dto/global/search-filters';
+import {
+  SEARCH_FILTERS_OPERATORS,
+  SearchFilterDTO,
+} from '@shared/dto/global/search-filters';
 import {
   ProjectionWidget,
   ProjectionWidgetData,
@@ -123,6 +126,12 @@ export class PostgresProjectionDataRepository
       case PROJECTION_VISUALIZATIONS.LINE_CHART:
       case PROJECTION_VISUALIZATIONS.BAR_CHART:
       case PROJECTION_VISUALIZATIONS.AREA_CHART:
+        dataFilters ??= [];
+        dataFilters.push({
+          name: 'type',
+          operator: SEARCH_FILTERS_OPERATORS.EQUALS,
+          values: [settings[widgetVisualization].vertical],
+        });
         return this.findProjectionCustomWidgetData(dataFilters, {
           valueFieldAlias: 'vertical',
         }) as unknown as Promise<CustomProjection>;

--- a/shared/dto/projections/projection-visualizations.constants.ts
+++ b/shared/dto/projections/projection-visualizations.constants.ts
@@ -8,7 +8,7 @@ export const PROJECTION_VISUALIZATIONS = {
 
 export const AVAILABLE_PROJECTION_VISUALIZATIONS = Object.values(
   PROJECTION_VISUALIZATIONS,
-);
+).filter((value) => value !== PROJECTION_VISUALIZATIONS.TABLE);
 
 export type ProjectionVisualizationsType =
   (typeof PROJECTION_VISUALIZATIONS)[keyof typeof PROJECTION_VISUALIZATIONS];


### PR DESCRIPTION
This pull request updates the handling of projection visualizations and improves filtering logic for custom widget data. The main changes include adding an explicit filter for chart widget types and refining the list of available visualizations to exclude tables.

**Visualization Filtering Enhancements:**

* For line, bar, and area charts, a new filter is added to `dataFilters` to ensure the widget data is filtered by the correct `type` using the vertical axis value and the `EQUALS` operator. This makes the data retrieval more precise.
* The import of `SEARCH_FILTERS_OPERATORS` from `@shared/dto/global/search-filters` is added to support the new filter logic.

**Visualization List Refinement:**

* The `AVAILABLE_PROJECTION_VISUALIZATIONS` list now excludes the `TABLE` visualization type, ensuring only supported chart types are included for further processing or display.