### PR TITLE
chore: Add unit to the projections filters

### DIFF
--- a/client/src/containers/sidebar/filter-settings/constants.ts
+++ b/client/src/containers/sidebar/filter-settings/constants.ts
@@ -7,7 +7,6 @@ export const PROJECTIONS_DEFAULT_FILTERS = [
   "country",
   "technology-type",
   "technology",
-  "application",
 ];
 
 export const DEFAULT_FILTERS_LABEL_MAP: Record<
@@ -26,10 +25,6 @@ export const DEFAULT_FILTERS_LABEL_MAP: Record<
   technology: {
     selected: "Technology",
     unSelected: "All technologies",
-  },
-  application: {
-    selected: "Application",
-    unSelected: "All applications",
   },
   "location-country-region": {
     selected: "Country",

--- a/client/src/hooks/use-filters.ts
+++ b/client/src/hooks/use-filters.ts
@@ -10,6 +10,7 @@ import { useQueryState } from "nuqs";
 import qs from "qs";
 
 import { addFilterQueryParam, removeFilterQueryParamValue } from "@/lib/utils";
+import { ADD_FILTER_MODE } from "@/lib/constants";
 
 export interface FilterQueryParam {
   name: string;
@@ -66,8 +67,11 @@ function useFilters() {
   );
 
   const addFilter = useCallback(
-    (newFilter: FilterQueryParam) => {
-      setFilters(addFilterQueryParam(filters, newFilter));
+    (
+      newFilter: FilterQueryParam,
+      mode: ADD_FILTER_MODE = ADD_FILTER_MODE.MERGE,
+    ) => {
+      setFilters(addFilterQueryParam(filters, newFilter, mode));
     },
     [filters, setFilters],
   );

--- a/client/src/hooks/use-scenario-filter.ts
+++ b/client/src/hooks/use-scenario-filter.ts
@@ -1,11 +1,14 @@
 import { useCallback, useMemo } from "react";
 
 import useFilters from "@/hooks/use-filters";
+import { ADD_FILTER_MODE } from "@/lib/constants";
 
 export default function useScenarioFilter() {
   const { filters, addFilter } = useFilters();
+
   const { scenarioFilter, selectedScenarios } = useMemo(() => {
     const scenarioFilter = filters.find((f) => f.name === "scenario");
+
     return {
       scenarioFilter,
       selectedScenarios: scenarioFilter?.values || [],
@@ -13,12 +16,13 @@ export default function useScenarioFilter() {
   }, [filters]);
 
   const toggleScenario = useCallback(
-    (value: string) => {
-      if (!selectedScenarios.includes(value)) {
-        addFilter({ name: "scenario", operator: "=", values: [value] });
-      }
+    (scenario: string) => {
+      addFilter(
+        { name: "scenario", operator: "=", values: [scenario] },
+        ADD_FILTER_MODE.REPLACE,
+      );
     },
-    [selectedScenarios, addFilter],
+    [addFilter],
   );
 
   return { scenarioFilter, selectedScenarios, toggleScenario };

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -29,3 +29,11 @@ export const CSS_CHART_COLORS = [
 ];
 
 export const MAX_PIE_CHART_LABELS_COUNT = CSS_CHART_COLORS.length - 1;
+
+export const ADD_FILTER_MODE = {
+  MERGE: 0,
+  REPLACE: 1,
+} as const;
+
+export type ADD_FILTER_MODE =
+  (typeof ADD_FILTER_MODE)[keyof typeof ADD_FILTER_MODE];

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { FilterQueryParam } from "@/hooks/use-filters";
+import { ADD_FILTER_MODE } from "@/lib/constants";
 import { CountryISOMap } from "@shared/constants/country-iso.map";
 import { SearchFilterOperatorType } from "@shared/dto/global/search-filters";
 import { ProjectionFilter } from "@shared/dto/projections/projection-filter.entity";
@@ -7,8 +9,6 @@ import { SearchFilterSchema } from "@shared/schemas/search-filters.schema";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
-
-import { FilterQueryParam } from "./../hooks/use-filters";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -31,6 +31,7 @@ export function isEmptyWidget(data: BaseWidgetWithData["data"]): boolean {
 export function addFilterQueryParam(
   filters: FilterQueryParam[],
   newFilter: FilterQueryParam,
+  mode: ADD_FILTER_MODE = ADD_FILTER_MODE.MERGE,
 ): FilterQueryParam[] {
   let updatedFilters = filters.slice();
 
@@ -40,15 +41,21 @@ export function addFilterQueryParam(
     updatedFilters = filters.map((filter) => {
       if (filter.name === newFilter.name) {
         // Merge values instead of replacing them, avoiding duplicates
-        const existingValues = new Set(filter.values);
-        newFilter.values.forEach((value) => existingValues.add(value));
-        const combinedValues = Array.from(existingValues);
+        if (mode === ADD_FILTER_MODE.MERGE) {
+          const existingValues = new Set(filter.values);
+          newFilter.values.forEach((value) => existingValues.add(value));
+          const combinedValues = Array.from(existingValues);
 
-        return {
-          ...filter,
-          values: combinedValues,
-          operator: filter.operator,
-        } as FilterQueryParam;
+          return {
+            ...filter,
+            values: combinedValues,
+            operator: filter.operator,
+          } as FilterQueryParam;
+        } else if (mode === ADD_FILTER_MODE.REPLACE) {
+          return newFilter;
+        }
+
+        throw Error("Invalid mode for addFilterQueryParam");
       }
 
       return filter;

--- a/shared/dto/projections/projection-filter.entity.ts
+++ b/shared/dto/projections/projection-filter.entity.ts
@@ -6,7 +6,6 @@ export const PROJECTION_FILTER_NAME_TO_FIELD_NAME = {
   scenario: 'scenario',
   technology: 'technology',
   'technology-type': 'technologyType',
-  application: 'application',
   country: 'country',
   unit: 'unit',
 };

--- a/shared/dto/projections/projection-filter.entity.ts
+++ b/shared/dto/projections/projection-filter.entity.ts
@@ -8,6 +8,7 @@ export const PROJECTION_FILTER_NAME_TO_FIELD_NAME = {
   'technology-type': 'technologyType',
   application: 'application',
   country: 'country',
+  unit: 'unit',
 };
 
 export const AVAILABLE_PROJECTION_FILTERS = Object.keys(


### PR DESCRIPTION
This pull request adds support for filtering projections by `unit` in the `PROJECTION_FILTER_NAME_TO_FIELD_NAME` mapping. This is a minor change that extends the available filters for projections.