### PR TITLE
feat: add table visualization support to projections sandbox API

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -263,6 +263,13 @@ export class PostgresProjectionDataRepository
       settings,
     )[0] as ProjectionVisualizationsType;
     switch (widgetVisualization) {
+      case PROJECTION_VISUALIZATIONS.TABLE:
+        const tableSettings = (settings as { table: { vertical: string } })
+          .table;
+        return this.findProjectionWidgetData([
+          ...dataFilters,
+          { name: 'type', operator: '=', values: [tableSettings.vertical] },
+        ]);
       case PROJECTION_VISUALIZATIONS.LINE_CHART:
       case PROJECTION_VISUALIZATIONS.BAR_CHART:
         // Only aggregate 'others' in findSimpleProjectionCustomWidgetData

--- a/api/test/e2e/projections/custom-projection.spec.ts
+++ b/api/test/e2e/projections/custom-projection.spec.ts
@@ -54,6 +54,32 @@ describe('Custom Projection API', () => {
     expect(firstProjectionDataForUnit[0]).toHaveProperty('year');
   });
 
+  test(`${c.getCustomProjection.path} should return a table custom projection with year/value data`, async () => {
+    const res = await testManager
+      .request()
+      .get(c.getCustomProjection.path)
+      .query({
+        settings: {
+          [PROJECTION_VISUALIZATIONS.TABLE]: {
+            vertical: 'market-potential',
+            color: 'country',
+          },
+        },
+      });
+    expect(res.status).toBe(200);
+    const resData = res.body?.data;
+
+    const unitKeys = Object.keys(resData);
+    expect(unitKeys.length).toBeGreaterThan(0);
+
+    const firstProjectionDataForUnit = resData[unitKeys[0]];
+    expect(Array.isArray(firstProjectionDataForUnit)).toBe(true);
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('year');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('value');
+    expect(firstProjectionDataForUnit[0]).not.toHaveProperty('color');
+    expect(firstProjectionDataForUnit[0]).not.toHaveProperty('vertical');
+  });
+
   test(`${c.getCustomProjection.path} should return an error when the settings for a custom projection are incorrect`, async () => {
     const res = await testManager
       .request()

--- a/client/src/containers/sandbox/projections-sandbox/index.tsx
+++ b/client/src/containers/sandbox/projections-sandbox/index.tsx
@@ -2,7 +2,10 @@
 import { FC, useMemo } from "react";
 
 import { CountryISOMap } from "@shared/constants/country-iso.map";
-import { CustomProjection } from "@shared/dto/projections/custom-projection.type";
+import {
+  CustomProjection,
+  SimpleProjection,
+} from "@shared/dto/projections/custom-projection.type";
 import { ProjectionVisualizationsType } from "@shared/dto/projections/projection-visualizations.constants";
 
 import { client } from "@/lib/queryClient";
@@ -48,7 +51,7 @@ const Sandbox: FC = () => {
       retry: 0,
       select: (res) => {
         if (colorIsCountry(settings)) {
-          const payload = res.body.data as CustomProjection;
+          const payload = res.body.data as SimpleProjection;
           return Object.fromEntries(
             Object.keys(payload).map((unit) => [
               unit,

--- a/client/src/containers/widget/projections/sandbox/index.tsx
+++ b/client/src/containers/widget/projections/sandbox/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   BubbleProjection,
   CustomProjection,
+  SimpleProjection,
 } from "@shared/dto/projections/custom-projection.type";
 import { ProjectionVisualizationsType } from "@shared/dto/projections/projection-visualizations.constants";
 
@@ -44,7 +45,7 @@ export default function SandboxWidget({
   const simpleChartProps = useMemo(
     () => ({
       indicator,
-      ...getSimpleChartProps(data, selectedUnit),
+      ...getSimpleChartProps(data as SimpleProjection, selectedUnit),
     }),
     [indicator, selectedUnit, data],
   );

--- a/client/src/containers/widget/utils.ts
+++ b/client/src/containers/widget/utils.ts
@@ -1,6 +1,7 @@
 import {
   BubbleProjection,
   CustomProjection,
+  SimpleProjection,
 } from "@shared/dto/projections/custom-projection.type";
 import { ProjectionWidgetData } from "@shared/dto/projections/projection-widget.entity";
 import { WidgetChartData } from "@shared/dto/widgets/base-widget-data.interface";
@@ -30,7 +31,7 @@ const getYears = (data: CustomProjection, unit: string): number[] => {
   return Array.from(new Set(data[unit].map((p) => p.year)));
 };
 export function getColors(
-  data: CustomProjection,
+  data: SimpleProjection | BubbleProjection,
   unit: string,
 ): (string | number)[] {
   if (!data[unit]) return [];
@@ -71,7 +72,7 @@ export function getBubbleChartProps(
   };
 }
 
-export function getSimpleChartProps(data: CustomProjection, unit: string) {
+export function getSimpleChartProps(data: SimpleProjection, unit: string) {
   const chartData: Record<string, number>[] = [];
   const years = getYears(data, unit);
 

--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -34,6 +34,10 @@ export const CUSTOM_PROJECTION_SETTINGS = {
     color: CHART_ATTRIBUTES,
     size: CHART_INDICATORS,
   },
+  [PROJECTION_VISUALIZATIONS.TABLE]: {
+    vertical: CHART_INDICATORS,
+    color: CHART_ATTRIBUTES,
+  },
 } as const;
 
 type AxisSettingsType = { value: string; label: string }[];
@@ -54,6 +58,10 @@ export type CustomProjectionSettingsType = {
     horizontal: AxisSettingsType;
     color: AxisSettingsType;
     size: AxisSettingsType;
+  };
+  [PROJECTION_VISUALIZATIONS.TABLE]: {
+    vertical: AxisSettingsType;
+    color: AxisSettingsType;
   };
 };
 
@@ -93,6 +101,10 @@ export const generateCustomProjectionSettings = (
       horizontal: filteredChartIndicators,
       color: filteredChartAttributes,
       size: filteredChartIndicators,
+    },
+    [PROJECTION_VISUALIZATIONS.TABLE]: {
+      vertical: filteredChartIndicators,
+      color: filteredChartAttributes,
     },
   } as CustomProjectionSettingsType;
 };

--- a/shared/dto/projections/custom-projection.type.ts
+++ b/shared/dto/projections/custom-projection.type.ts
@@ -17,4 +17,11 @@ export type BubbleProjection = {
   }[];
 };
 
-export type CustomProjection = SimpleProjection | BubbleProjection;
+export type TableProjection = {
+  [unit: string]: {
+    year: number;
+    value: number;
+  }[];
+};
+
+export type CustomProjection = SimpleProjection | BubbleProjection | TableProjection;

--- a/shared/dto/projections/projection-visualizations.constants.ts
+++ b/shared/dto/projections/projection-visualizations.constants.ts
@@ -7,7 +7,7 @@ export const PROJECTION_VISUALIZATIONS = {
 
 export const AVAILABLE_PROJECTION_VISUALIZATIONS = Object.values(
   PROJECTION_VISUALIZATIONS,
-).filter((value) => value !== PROJECTION_VISUALIZATIONS.TABLE);
+);
 
 export type ProjectionVisualizationsType =
   (typeof PROJECTION_VISUALIZATIONS)[keyof typeof PROJECTION_VISUALIZATIONS];

--- a/shared/schemas/custom-projection-settings.schema.ts
+++ b/shared/schemas/custom-projection-settings.schema.ts
@@ -46,6 +46,9 @@ export const CustomProjectionSettingsSchema = z.object({
     z.object({
       [PROJECTION_VISUALIZATIONS.BUBBLE_CHART]: BubbleChartSchema,
     }),
+    z.object({
+      [PROJECTION_VISUALIZATIONS.TABLE]: SimpleVisualizationSchema,
+    }),
   ]),
 });
 


### PR DESCRIPTION
### Summary

- Include `table` in available sandbox visualizations and add it to Zod validation schema, settings config, and shared types
- Handle `TABLE` case in the backend repository, reusing the existing `findProjectionWidgetData()` query for `{year, value}` aggregation
- Add E2E test verifying the table custom projection endpoint returns the expected data shape  