### PR TITLE
feat: add data breakdown support to projections sandbox

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -1,5 +1,5 @@
 import { DataSource, Repository } from 'typeorm';
-import { Logger, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { ProjectionData } from '@shared/dto/projections/projection-data.entity';
 import { IProjectionDataRepository } from '@api/infrastructure/projection-data-repository.interface';
@@ -258,10 +258,26 @@ export class PostgresProjectionDataRepository
   public async previewProjectionCustomWidget(
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
+    breakdown?: string,
   ): Promise<CustomProjection> {
     const widgetVisualization = Object.keys(
       settings,
     )[0] as ProjectionVisualizationsType;
+
+    if (breakdown) {
+      if (widgetVisualization === PROJECTION_VISUALIZATIONS.BUBBLE_CHART) {
+        throw new BadRequestException(
+          'Breakdown is not supported for bubble chart visualizations',
+        );
+      }
+      return this.findBreakdownProjectionData(
+        widgetVisualization,
+        dataFilters,
+        settings,
+        breakdown,
+      );
+    }
+
     switch (widgetVisualization) {
       case PROJECTION_VISUALIZATIONS.TABLE:
         const tableSettings = (settings as { table: { vertical: string } })
@@ -507,5 +523,132 @@ export class PostgresProjectionDataRepository
           `Visualization type ${widgetVisualization} is not supported.`,
         );
     }
+  }
+
+  private async findBreakdownProjectionData(
+    widgetVisualization: ProjectionVisualizationsType,
+    dataFilters: SearchFilterDTO[],
+    settings: CustomProjectionSettingsType,
+    breakdown: string,
+  ): Promise<CustomProjection> {
+    const verticalAxis = settings[widgetVisualization].vertical;
+    const breakdownFieldName =
+      PROJECTION_FILTER_NAME_TO_FIELD_NAME[breakdown] || breakdown;
+
+    const baseQueryBuilder = this.dataSource
+      .getRepository(Projection)
+      .createQueryBuilder('projection')
+      .select('projectionData.year', 'year')
+      .addSelect(
+        `CASE
+          WHEN projection.unit = '%' THEN AVG(projectionData.value)
+          ELSE SUM(projectionData.value)
+        END`,
+        'value',
+      )
+      .addSelect('projection.unit', 'unit')
+      .addSelect(`projection.${breakdownFieldName}`, 'breakdown_group')
+      .innerJoin('projection.projectionData', 'projectionData')
+      .where('projection.type = :type', { type: verticalAxis })
+      .groupBy('projectionData.year')
+      .addGroupBy('projection.unit')
+      .addGroupBy(`projection.${breakdownFieldName}`)
+      .orderBy('projectionData.year', 'ASC');
+
+    QueryBuilderUtils.applySearchFilters(baseQueryBuilder, dataFilters, {
+      alias: 'projection',
+      filterNameToFieldNameMap: PROJECTION_FILTER_NAME_TO_FIELD_NAME,
+    });
+
+    const finalQuery = `
+      WITH base_data AS (
+        ${baseQueryBuilder.getSql()}
+      ),
+      global_breakdown_totals AS (
+        SELECT
+          breakdown_group,
+          SUM(value) as total_value
+        FROM base_data
+        GROUP BY breakdown_group
+      ),
+      ranked_breakdown AS (
+        SELECT
+          breakdown_group,
+          total_value,
+          ROW_NUMBER() OVER (ORDER BY total_value DESC) as rank
+        FROM global_breakdown_totals
+      ),
+      processed_data AS (
+        SELECT
+          bd.unit,
+          bd.year,
+          CASE
+            WHEN rb.rank <= 9 THEN bd.breakdown_group::text
+            ELSE 'Others'
+          END as final_group,
+          SUM(bd.value) as value
+        FROM base_data bd
+        JOIN ranked_breakdown rb ON bd.breakdown_group = rb.breakdown_group
+        GROUP BY bd.unit, bd.year,
+                 CASE
+                   WHEN rb.rank <= 9 THEN bd.breakdown_group::text
+                   ELSE 'Others'
+                 END
+      ),
+      year_totals AS (
+        SELECT
+          unit,
+          year,
+          SUM(value) as total
+        FROM processed_data
+        GROUP BY unit, year
+      ),
+      breakdown_groups AS (
+        SELECT
+          pd.unit,
+          CASE
+            WHEN pd.final_group = 'Others' THEN 'Others'
+            ELSE ${this.getConditionalHumanizationSql('pd.final_group', breakdown)}
+          END as group_label,
+          JSON_AGG(
+            JSON_BUILD_OBJECT(
+              'label', pd.year::text,
+              'value', pd.value,
+              'total', yt.total
+            )
+            ORDER BY pd.year ASC
+          ) as data
+        FROM processed_data pd
+        JOIN year_totals yt ON pd.unit = yt.unit AND pd.year = yt.year
+        GROUP BY pd.unit, pd.final_group,
+                 CASE
+                   WHEN pd.final_group = 'Others' THEN 'Others'
+                   ELSE ${this.getConditionalHumanizationSql('pd.final_group', breakdown)}
+                 END
+      )
+      SELECT
+        JSON_OBJECT_AGG(
+          unit,
+          unit_data
+        ) as data
+      FROM (
+        SELECT
+          unit,
+          JSON_AGG(
+            JSON_BUILD_OBJECT(
+              'label', group_label,
+              'data', data
+            )
+            ORDER BY group_label
+          ) as unit_data
+        FROM breakdown_groups
+        GROUP BY unit
+      ) as grouped_data
+    `;
+
+    const parameters = Object.values(baseQueryBuilder.getParameters()).flat();
+    const result = await this.dataSource.query(finalQuery, parameters);
+
+    return result[0]?.data || {};
   }
 }

--- a/api/src/infrastructure/projection-data-repository.interface.ts
+++ b/api/src/infrastructure/projection-data-repository.interface.ts
@@ -20,5 +20,6 @@ export interface IProjectionDataRepository extends Repository<ProjectionData> {
   previewProjectionCustomWidget(
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
+    breakdown?: string,
   ): Promise<CustomProjection>;
 }

--- a/api/src/modules/projections/projections.service.ts
+++ b/api/src/modules/projections/projections.service.ts
@@ -46,10 +46,11 @@ export class ProjectionsService extends AppBaseService<
   public async generateCustomProjection(
     query: SearchFiltersDTO & CustomProjectionSettingsSchemaType,
   ): Promise<CustomProjection> {
-    const { settings, dataFilters = [] } = query;
+    const { settings, dataFilters = [], breakdown } = query;
     return this.projectionDataRepository.previewProjectionCustomWidget(
       dataFilters,
       settings,
+      breakdown,
     );
   }
 

--- a/api/test/e2e/projections/custom-projection.spec.ts
+++ b/api/test/e2e/projections/custom-projection.spec.ts
@@ -96,6 +96,158 @@ describe('Custom Projection API', () => {
     expect(res.body.errors).toBeDefined();
   });
 
+  describe('Breakdown', () => {
+    test(`${c.getCustomProjection.path} should return breakdown format for line chart with breakdown`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+          breakdown: 'technology',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      const firstUnitData = resData[unitKeys[0]];
+      expect(Array.isArray(firstUnitData)).toBe(true);
+      expect(firstUnitData.length).toBeGreaterThan(0);
+
+      // Each entry should have label (breakdown value) and data array
+      const firstGroup = firstUnitData[0];
+      expect(firstGroup).toHaveProperty('label');
+      expect(firstGroup).toHaveProperty('data');
+      expect(Array.isArray(firstGroup.data)).toBe(true);
+      expect(firstGroup.data.length).toBeGreaterThan(0);
+
+      // Each data entry should have label (year), value, and total
+      const firstDataPoint = firstGroup.data[0];
+      expect(firstDataPoint).toHaveProperty('label');
+      expect(firstDataPoint).toHaveProperty('value');
+      expect(firstDataPoint).toHaveProperty('total');
+
+      // Should NOT have simple projection properties
+      expect(firstGroup).not.toHaveProperty('year');
+      expect(firstGroup).not.toHaveProperty('vertical');
+      expect(firstGroup).not.toHaveProperty('color');
+    });
+
+    test(`${c.getCustomProjection.path} should return breakdown format for table with breakdown`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.TABLE]: {
+              vertical: 'market-potential',
+              color: 'country',
+            },
+          },
+          breakdown: 'scenario',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      const firstUnitData = resData[unitKeys[0]];
+      expect(Array.isArray(firstUnitData)).toBe(true);
+      expect(firstUnitData.length).toBeGreaterThan(0);
+
+      const firstGroup = firstUnitData[0];
+      expect(firstGroup).toHaveProperty('label');
+      expect(firstGroup).toHaveProperty('data');
+      expect(Array.isArray(firstGroup.data)).toBe(true);
+
+      const firstDataPoint = firstGroup.data[0];
+      expect(firstDataPoint).toHaveProperty('label');
+      expect(firstDataPoint).toHaveProperty('value');
+      expect(firstDataPoint).toHaveProperty('total');
+    });
+
+    test(`${c.getCustomProjection.path} should return normal data when no breakdown is provided (regression)`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      const firstUnitData = resData[unitKeys[0]];
+      expect(Array.isArray(firstUnitData)).toBe(true);
+
+      // Should have SimpleProjection shape
+      const firstEntry = firstUnitData[0];
+      expect(firstEntry).toHaveProperty('year');
+      expect(firstEntry).toHaveProperty('vertical');
+      expect(firstEntry).toHaveProperty('color');
+
+      // Should NOT have breakdown shape
+      expect(firstEntry).not.toHaveProperty('data');
+    });
+
+    test(`${c.getCustomProjection.path} should return 400 for invalid breakdown attribute`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+          breakdown: 'invalid-name',
+        });
+
+      expect(res.status).toBe(400);
+    });
+
+    test(`${c.getCustomProjection.path} should limit breakdown groups to max 10 (including Others)`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'scenario',
+            },
+          },
+          breakdown: 'country',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      for (const unit of unitKeys) {
+        expect(resData[unit].length).toBeLessThanOrEqual(10);
+      }
+    });
+  });
+
   afterAll(async () => {
     await testManager.clearDatabase();
     await testManager.close();

--- a/client/src/containers/widget/utils.ts
+++ b/client/src/containers/widget/utils.ts
@@ -25,7 +25,10 @@ export function getIndexOfLargestValue(
   return index;
 }
 
-const getYears = (data: CustomProjection, unit: string): number[] => {
+const getYears = (
+  data: SimpleProjection | BubbleProjection,
+  unit: string,
+): number[] => {
   if (!data[unit]) return [];
 
   return Array.from(new Set(data[unit].map((p) => p.year)));

--- a/shared/dto/projections/custom-projection.type.ts
+++ b/shared/dto/projections/custom-projection.type.ts
@@ -24,4 +24,19 @@ export type TableProjection = {
   }[];
 };
 
-export type CustomProjection = SimpleProjection | BubbleProjection | TableProjection;
+export type BreakdownProjection = {
+  [unit: string]: Array<{
+    label: string;
+    data: Array<{
+      label: string;
+      value: number;
+      total: number;
+    }>;
+  }>;
+};
+
+export type CustomProjection =
+  | SimpleProjection
+  | BubbleProjection
+  | TableProjection
+  | BreakdownProjection;

--- a/shared/schemas/custom-projection-settings.schema.ts
+++ b/shared/schemas/custom-projection-settings.schema.ts
@@ -50,6 +50,7 @@ export const CustomProjectionSettingsSchema = z.object({
       [PROJECTION_VISUALIZATIONS.TABLE]: SimpleVisualizationSchema,
     }),
   ]),
+  breakdown: AttributeValue.optional(),
 });
 
 export type CustomProjectionSettingsSchemaType = z.infer<


### PR DESCRIPTION
### Summary

- Add optional `breakdown` query parameter to `GET /projections/custom-widget` that groups projection data by a secondary attribute (e.g., technology, scenario, country)
- Returns a cross-tabulated structure with `{ label, data: [{ label, value, total }] }` per unit, analogous to the existing surveys breakdown feature
- Top 9 breakdown groups are shown by global total, the rest are aggregated into "Others"
- Bubble chart + breakdown is rejected with 400
- Invalid breakdown attribute names are rejected via Zod validation

### Changes

- `shared/`: Added `BreakdownProjection` type and `breakdown` field to Zod schema
- `api/src/`: Updated repository interface, service passthrough, and implemented `findBreakdownProjectionData` with CTE-based SQL aggregation
- `api/test/`: Added 5 E2E tests covering breakdown format, regression, validation, and Others grouping
