### PR TITLE
show table in sandbox projections

### DIFF
--- a/client/src/containers/sidebar/projections-settings/constants.ts
+++ b/client/src/containers/sidebar/projections-settings/constants.ts
@@ -31,6 +31,8 @@ export const BUBBLE_CHART_ATTRIBUTE_TO_LABEL_MAP = {
   "technology-type": "Technology type",
   application: "Application",
   country: "Country",
+  unit: "Unit",
+  category: "Category",
 };
 
 export const BUBBLE_TOOLTIP_LABELS_MAP: { [key: string]: string } = {

--- a/client/src/containers/sidebar/projections-settings/utils.ts
+++ b/client/src/containers/sidebar/projections-settings/utils.ts
@@ -13,11 +13,12 @@ export function isSimpleChartSettings(
   settings: CustomProjectionSettingsType | null | undefined,
 ): settings is
   | { line_chart: SimpleChartSettings }
-  | { bar_chart: SimpleChartSettings } {
+  | { bar_chart: SimpleChartSettings }
+  | { table: SimpleChartSettings } {
   return (
     !!settings &&
     typeof settings === "object" &&
-    ("line_chart" in settings || "bar_chart" in settings)
+    ("line_chart" in settings || "bar_chart" in settings || "table" in settings)
   );
 }
 

--- a/client/src/containers/widget/projections/sandbox/index.tsx
+++ b/client/src/containers/widget/projections/sandbox/index.tsx
@@ -24,6 +24,7 @@ import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 import WidgetHeader from "@/containers/widget/widget-header";
 
 import { Card } from "@/components/ui/card";
+import TableView from "@/containers/widget/table";
 
 export interface SandboxWidgetProps {
   indicator: string;
@@ -116,6 +117,20 @@ export default function SandboxWidget({
         );
       }
       return null;
+    case "table":
+      return (
+        <Card className={cn("relative p-0", className)}>
+          <WidgetHeader
+            title={indicator}
+            className="pb-0"
+            select={selectComponent}
+          />
+          <TableView
+            indicator={indicator}
+            data={data[selectedUnit] as Record<string, number>[]}
+          />
+        </Card>
+      );
     default:
       console.error(
         `Widget: Unsupported visualization type "${visualization}" for indicator "${indicator}".`,

--- a/client/src/containers/widget/table/index.tsx
+++ b/client/src/containers/widget/table/index.tsx
@@ -30,7 +30,8 @@ const TableView: FC<TableViewProps> = ({ indicator, data }) => {
               </TableCell>
               <TableCell className="pl-6" width="50%">
                 {formatNumber(d.value, {
-                  maximumFractionDigits: 0,
+                  maximumFractionDigits:
+                    Math.abs(d.value) > 0 && Math.abs(d.value) < 1 ? 2 : 0,
                   notation: "compact",
                   compactDisplay: "short",
                 })}

--- a/client/src/hooks/use-settings.ts
+++ b/client/src/hooks/use-settings.ts
@@ -55,6 +55,7 @@ function useSettings() {
       switch (visualization) {
         case "bar_chart":
         case "line_chart":
+        case "table":
           if (isSimpleChartSettings(settings)) {
             const currentVisualization: ProjectionVisualizationsType =
               getKeys(settings)[0];
@@ -119,6 +120,10 @@ function useSettings() {
               [key]: value,
             },
           });
+        } else if ("table" in settings) {
+          setSettings({
+            table: { ...settings.table, [key]: value },
+          });
         }
       }
 
@@ -158,6 +163,10 @@ function useSettings() {
         } else if ("bar_chart" in settings) {
           setSettings({
             bar_chart: { ...settings.bar_chart, [key]: value },
+          });
+        } else if ("table" in settings) {
+          setSettings({
+            table: { ...settings.table, [key]: value },
           });
         }
       }


### PR DESCRIPTION
## Add table visualization support for sandbox projections

### Overview
Extend projections sandbox to support a table visualization alongside existing chart types, with improved numeric formatting and configurable settings.

### Changes
- Add `table` as a supported simple chart type in projection settings utilities and `useSettings`, including reading and updating table-specific settings.
- Extend sandbox widget to render a `TableView` when `visualization` is `"table"`, wiring indicator, unit-filtered data, and shared header UI.
- Update `TableView` value formatting to display up to 2 decimal places for values between 0 and 1, keeping compact notation for larger numbers.
- Enrich sidebar bubble chart configuration with `unit` and `category` attributes for more detailed breakdowns.

### Breaking Changes
None.

### Technical Details
- Related issue: [SIRH-234](https://vizzuality.atlassian.net/browse/SIRH-234)

[SIRH-234]: https://vizzuality.atlassian.net/browse/SIRH-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ