### PR TITLE
feat: add "Others" aggregation toggle as a Sandbox setting

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -15,7 +15,10 @@ import {
   ProjectionFilter,
 } from '@shared/dto/projections/projection-filter.entity';
 import { CustomProjection } from '@shared/dto/projections/custom-projection.type';
-import { CustomProjectionSettingsType } from '@shared/schemas/custom-projection-settings.schema';
+import {
+  CustomProjectionSettingsType,
+  OthersAggregationType,
+} from '@shared/schemas/custom-projection-settings.schema';
 import {
   PROJECTION_VISUALIZATIONS,
   ProjectionVisualizationsType,
@@ -158,6 +161,7 @@ export class PostgresProjectionDataRepository
     widgetVisualization: ProjectionVisualizationsType,
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
+    othersAggregation: OthersAggregationType = 'visible',
   ): Promise<CustomProjection> {
     const verticalAxis = settings[widgetVisualization].vertical;
     const colorAxis =
@@ -187,13 +191,16 @@ export class PostgresProjectionDataRepository
       filterNameToFieldNameMap: PROJECTION_FILTER_NAME_TO_FIELD_NAME,
     });
 
+    const showOthers = othersAggregation !== 'hidden';
+    const rankLimit = showOthers ? 9 : 10;
+
     // Use database-level logic to handle top colors per unit
     const finalQuery = `
       WITH base_data AS (
         ${baseQueryBuilder.getSql()}
       ),
       unit_color_totals AS (
-        SELECT 
+        SELECT
           unit,
           color,
           SUM(vertical) as total_vertical
@@ -201,7 +208,7 @@ export class PostgresProjectionDataRepository
         GROUP BY unit, color
       ),
       ranked_colors AS (
-        SELECT 
+        SELECT
           unit,
           color,
           total_vertical,
@@ -209,39 +216,48 @@ export class PostgresProjectionDataRepository
         FROM unit_color_totals
       ),
       processed_data AS (
-        SELECT 
+        SELECT
           bd.unit,
           bd.year,
-          CASE 
-            WHEN rc.rank <= 9 THEN bd.color::text
+          ${
+            showOthers
+              ? `CASE
+            WHEN rc.rank <= ${rankLimit} THEN bd.color::text
             ELSE 'Others'
-          END as final_color,
+          END as final_color,`
+              : `bd.color::text as final_color,`
+          }
           SUM(bd.vertical) as vertical
         FROM base_data bd
         JOIN ranked_colors rc ON bd.unit = rc.unit AND bd.color = rc.color
-        GROUP BY bd.unit, bd.year, 
-                 CASE 
-                   WHEN rc.rank <= 9 THEN bd.color::text
+        ${!showOthers ? `WHERE rc.rank <= ${rankLimit}` : ''}
+        GROUP BY bd.unit, bd.year,
+                 ${
+                   showOthers
+                     ? `CASE
+                   WHEN rc.rank <= ${rankLimit} THEN bd.color::text
                    ELSE 'Others'
-                 END
+                 END`
+                     : `bd.color::text`
+                 }
       )
-      SELECT 
+      SELECT
         JSON_OBJECT_AGG(
           unit,
           unit_data
         ) as data
       FROM (
-        SELECT 
+        SELECT
           unit,
           JSON_AGG(
             JSON_BUILD_OBJECT(
               'year', year,
-              'color', CASE 
+              'color', CASE
                 WHEN final_color = 'Others' THEN 'Others'
                 ELSE ${this.getConditionalHumanizationSql('final_color', colorFieldName)}
               END,
               'vertical', vertical
-            ) 
+            )
             ORDER BY year ASC, final_color
           ) as unit_data
         FROM processed_data
@@ -259,6 +275,7 @@ export class PostgresProjectionDataRepository
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
     breakdown?: string,
+    othersAggregation: OthersAggregationType = 'visible',
   ): Promise<CustomProjection> {
     const widgetVisualization = Object.keys(
       settings,
@@ -275,6 +292,7 @@ export class PostgresProjectionDataRepository
         dataFilters,
         settings,
         breakdown,
+        othersAggregation,
       );
     }
 
@@ -293,6 +311,7 @@ export class PostgresProjectionDataRepository
           widgetVisualization,
           dataFilters,
           settings,
+          othersAggregation,
         );
       case PROJECTION_VISUALIZATIONS.BUBBLE_CHART:
         const bubble =
@@ -420,10 +439,13 @@ export class PostgresProjectionDataRepository
             return `$${Number(paramIndex) + sizeParams.length + verticalParams.length}`;
           });
 
+        const showOthers = othersAggregation !== 'hidden';
+        const rankLimit = showOthers ? 9 : 10;
+
         // Combined query that joins all three metrics and groups by unit
         const combinedQuery = `
           WITH combined_data AS (
-            SELECT 
+            SELECT
               size.unit,
               size.bubble,
               size.color,
@@ -433,18 +455,18 @@ export class PostgresProjectionDataRepository
               COALESCE(horizontal.horizontal, 0) AS horizontal
             FROM (${sizeQueryBuilder.getSql()}) AS size
             LEFT JOIN (${verticalSql}) AS vertical
-              ON size.color = vertical.color 
-              AND size.bubble = vertical.bubble 
+              ON size.color = vertical.color
+              AND size.bubble = vertical.bubble
               AND size.year = vertical.year
               AND size.unit = vertical.unit
             LEFT JOIN (${horizontalSql}) AS horizontal
-              ON size.color = horizontal.color 
-              AND size.bubble = horizontal.bubble 
+              ON size.color = horizontal.color
+              AND size.bubble = horizontal.bubble
               AND size.year = horizontal.year
               AND size.unit = horizontal.unit
           ),
           color_totals AS (
-            SELECT 
+            SELECT
               unit,
               bubble,
               color,
@@ -453,36 +475,45 @@ export class PostgresProjectionDataRepository
             GROUP BY unit, bubble, color
           ),
           ranked_colors AS (
-            SELECT 
+            SELECT
               unit,
               bubble,
               color,
               total_horizontal,
               ROW_NUMBER() OVER (
-                PARTITION BY unit, bubble 
+                PARTITION BY unit, bubble
                 ORDER BY total_horizontal DESC
               ) as rank
             FROM color_totals
           ),
           processed_data AS (
-            SELECT 
+            SELECT
               cd.unit,
               cd.bubble,
               cd.year,
-              CASE 
-                WHEN rc.rank <= 9 THEN cd.color::text
+              ${
+                showOthers
+                  ? `CASE
+                WHEN rc.rank <= ${rankLimit} THEN cd.color::text
                 ELSE 'Others'
-              END as final_color,
+              END as final_color,`
+                  : `cd.color::text as final_color,`
+              }
               SUM(cd.size) as size,
               SUM(cd.vertical) as vertical,
               SUM(cd.horizontal) as horizontal
             FROM combined_data cd
             JOIN ranked_colors rc ON cd.unit = rc.unit AND cd.bubble = rc.bubble AND cd.color = rc.color
-            GROUP BY cd.unit, cd.bubble, cd.year, 
-                     CASE 
-                       WHEN rc.rank <= 9 THEN cd.color::text
+            ${!showOthers ? `WHERE rc.rank <= ${rankLimit}` : ''}
+            GROUP BY cd.unit, cd.bubble, cd.year,
+                     ${
+                       showOthers
+                         ? `CASE
+                       WHEN rc.rank <= ${rankLimit} THEN cd.color::text
                        ELSE 'Others'
-                     END
+                     END`
+                         : `cd.color::text`
+                     }
           )
           SELECT 
             JSON_OBJECT_AGG(
@@ -530,6 +561,7 @@ export class PostgresProjectionDataRepository
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
     breakdown: string,
+    othersAggregation: OthersAggregationType = 'visible',
   ): Promise<CustomProjection> {
     const verticalAxis = settings[widgetVisualization].vertical;
     const breakdownFieldName =
@@ -560,6 +592,9 @@ export class PostgresProjectionDataRepository
       filterNameToFieldNameMap: PROJECTION_FILTER_NAME_TO_FIELD_NAME,
     });
 
+    const showOthers = othersAggregation !== 'hidden';
+    const rankLimit = showOthers ? 9 : 10;
+
     const finalQuery = `
       WITH base_data AS (
         ${baseQueryBuilder.getSql()}
@@ -582,18 +617,27 @@ export class PostgresProjectionDataRepository
         SELECT
           bd.unit,
           bd.year,
-          CASE
-            WHEN rb.rank <= 9 THEN bd.breakdown_group::text
+          ${
+            showOthers
+              ? `CASE
+            WHEN rb.rank <= ${rankLimit} THEN bd.breakdown_group::text
             ELSE 'Others'
-          END as final_group,
+          END as final_group,`
+              : `bd.breakdown_group::text as final_group,`
+          }
           SUM(bd.value) as value
         FROM base_data bd
         JOIN ranked_breakdown rb ON bd.breakdown_group = rb.breakdown_group
+        ${!showOthers ? `WHERE rb.rank <= ${rankLimit}` : ''}
         GROUP BY bd.unit, bd.year,
-                 CASE
-                   WHEN rb.rank <= 9 THEN bd.breakdown_group::text
+                 ${
+                   showOthers
+                     ? `CASE
+                   WHEN rb.rank <= ${rankLimit} THEN bd.breakdown_group::text
                    ELSE 'Others'
-                 END
+                 END`
+                     : `bd.breakdown_group::text`
+                 }
       ),
       year_totals AS (
         SELECT

--- a/api/src/infrastructure/projection-data-repository.interface.ts
+++ b/api/src/infrastructure/projection-data-repository.interface.ts
@@ -3,7 +3,10 @@ import { CustomProjection } from '@shared/dto/projections/custom-projection.type
 import { ProjectionData } from '@shared/dto/projections/projection-data.entity';
 import { ProjectionFilter } from '@shared/dto/projections/projection-filter.entity';
 import { ProjectionWidget } from '@shared/dto/projections/projection-widget.entity';
-import { CustomProjectionSettingsType } from '@shared/schemas/custom-projection-settings.schema';
+import {
+  CustomProjectionSettingsType,
+  OthersAggregationType,
+} from '@shared/schemas/custom-projection-settings.schema';
 import { Repository } from 'typeorm';
 
 export const ProjectionDataRepository = Symbol('IProjectionDataRepository');
@@ -21,5 +24,6 @@ export interface IProjectionDataRepository extends Repository<ProjectionData> {
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,
     breakdown?: string,
+    othersAggregation?: OthersAggregationType,
   ): Promise<CustomProjection>;
 }

--- a/api/src/modules/projections/projections.service.ts
+++ b/api/src/modules/projections/projections.service.ts
@@ -46,11 +46,12 @@ export class ProjectionsService extends AppBaseService<
   public async generateCustomProjection(
     query: SearchFiltersDTO & CustomProjectionSettingsSchemaType,
   ): Promise<CustomProjection> {
-    const { settings, dataFilters = [], breakdown } = query;
+    const { settings, dataFilters = [], breakdown, othersAggregation } = query;
     return this.projectionDataRepository.previewProjectionCustomWidget(
       dataFilters,
       settings,
       breakdown,
+      othersAggregation,
     );
   }
 

--- a/api/test/e2e/projections/custom-projection.spec.ts
+++ b/api/test/e2e/projections/custom-projection.spec.ts
@@ -248,6 +248,108 @@ describe('Custom Projection API', () => {
     });
   });
 
+  describe('Others Aggregation', () => {
+    test(`${c.getCustomProjectionSettings.path} should include othersAggregation options in settings`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjectionSettings.path);
+
+      expect(res.status).toBe(200);
+      expect(res.body?.data.othersAggregation).toStrictEqual([
+        { value: 'visible', label: 'Visible' },
+        { value: 'hidden', label: 'Hidden' },
+      ]);
+    });
+
+    test(`${c.getCustomProjection.path} should not include "Others" entries when othersAggregation=hidden`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+          othersAggregation: 'hidden',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      for (const unit of unitKeys) {
+        const colors = resData[unit].map(
+          (entry: { color: string }) => entry.color,
+        );
+        expect(colors).not.toContain('Others');
+      }
+    });
+
+    test(`${c.getCustomProjection.path} should include "Others" entries when othersAggregation=visible and data exceeds top 9`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+          othersAggregation: 'visible',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      // Check that distinct colors per unit don't exceed 10 (top 9 + Others)
+      for (const unit of unitKeys) {
+        const uniqueColors = [
+          ...new Set(
+            resData[unit].map((entry: { color: string }) => entry.color),
+          ),
+        ];
+        expect(uniqueColors.length).toBeLessThanOrEqual(10);
+      }
+    });
+
+    test(`${c.getCustomProjection.path} should not include "Others" in breakdown when othersAggregation=hidden`, async () => {
+      const res = await testManager
+        .request()
+        .get(c.getCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'scenario',
+            },
+          },
+          breakdown: 'country',
+          othersAggregation: 'hidden',
+        });
+
+      expect(res.status).toBe(200);
+      const resData = res.body?.data;
+
+      const unitKeys = Object.keys(resData);
+      expect(unitKeys.length).toBeGreaterThan(0);
+
+      for (const unit of unitKeys) {
+        const labels = resData[unit].map(
+          (entry: { label: string }) => entry.label,
+        );
+        expect(labels).not.toContain('Others');
+      }
+    });
+  });
+
   afterAll(async () => {
     await testManager.clearDatabase();
     await testManager.close();

--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -17,8 +17,14 @@ export const CHART_ATTRIBUTES = Object.keys(
   label: key.replace(/-/g, ' ').replace(/^\w/g, (char) => char.toUpperCase()),
 }));
 
+export const OTHERS_AGGREGATION_OPTIONS = [
+  { value: 'visible', label: 'Visible' },
+  { value: 'hidden', label: 'Hidden' },
+] as const;
+
 export const CUSTOM_PROJECTION_SETTINGS = {
   availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
+  othersAggregation: OTHERS_AGGREGATION_OPTIONS,
   [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
     vertical: CHART_INDICATORS,
     color: CHART_ATTRIBUTES,
@@ -44,6 +50,7 @@ type AxisSettingsType = { value: string; label: string }[];
 
 export type CustomProjectionSettingsType = {
   availableVisualizations: typeof AVAILABLE_PROJECTION_VISUALIZATIONS;
+  othersAggregation: typeof OTHERS_AGGREGATION_OPTIONS;
   [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
     vertical: AxisSettingsType;
     color: AxisSettingsType;
@@ -87,6 +94,7 @@ export const generateCustomProjectionSettings = (
 
   return {
     availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
+    othersAggregation: OTHERS_AGGREGATION_OPTIONS,
     [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
       vertical: filteredChartIndicators,
       color: filteredChartAttributes,

--- a/shared/schemas/custom-projection-settings.schema.ts
+++ b/shared/schemas/custom-projection-settings.schema.ts
@@ -35,6 +35,12 @@ const BubbleChartSchema = z.object({
   size: IndicatorValue,
 });
 
+export const OthersAggregationValues = ['visible', 'hidden'] as const;
+export const OthersAggregationSchema = z
+  .enum(OthersAggregationValues)
+  .optional()
+  .default('visible');
+
 export const CustomProjectionSettingsSchema = z.object({
   settings: z.union([
     z.object({
@@ -51,6 +57,7 @@ export const CustomProjectionSettingsSchema = z.object({
     }),
   ]),
   breakdown: AttributeValue.optional(),
+  othersAggregation: OthersAggregationSchema,
 });
 
 export type CustomProjectionSettingsSchemaType = z.infer<
@@ -59,3 +66,5 @@ export type CustomProjectionSettingsSchemaType = z.infer<
 
 export type CustomProjectionSettingsType =
   CustomProjectionSettingsSchemaType['settings'];
+
+export type OthersAggregationType = z.infer<typeof OthersAggregationSchema>;


### PR DESCRIPTION
### Summary

Adds a new othersAggregation query parameter to the projections sandbox API, allowing users to toggle whether items beyond the top results are grouped into an "Others" bucket or hidden entirely.

### Changes

- Shared schema/DTO: Added othersAggregation field ('visible' | 'hidden', defaults to 'visible') to CustomProjectionSettingsSchema and exposed available options in the settings endpoint response.
- API service & interface: Passed othersAggregation through to the repository layer.
- Repository SQL: Conditionally applies "Others" grouping in all 3 query methods (simple projections, bubble chart, breakdown):
- visible (default): top 9 + "Others" bucket (existing behavior, no breaking change)
- hidden: top 10 items only, no aggregation
- E2E tests: 4 new tests covering settings response, hidden/visible behavior for simple projections, and breakdown queries.