### PR TITLE
Fix projections sandbox color selector showing invalid options

### DIFF
--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -16,10 +16,6 @@ export const CHART_ATTRIBUTES = Object.keys(
   value: key,
   label: key.replace(/-/g, ' ').replace(/^\w/g, (char) => char.toUpperCase()),
 }));
-const COLOR_EXCLUDED_ATTRIBUTES = ['unit', 'category'];
-export const CHART_COLOR_ATTRIBUTES = CHART_ATTRIBUTES.filter(
-  (attr) => !COLOR_EXCLUDED_ATTRIBUTES.includes(attr.value),
-);
 
 export const OTHERS_AGGREGATION_OPTIONS = [
   { value: 'visible', label: 'Visible' },

--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -26,6 +26,11 @@ export const OTHERS_AGGREGATION_OPTIONS = [
   { value: 'hidden', label: 'Hidden' },
 ] as const;
 
+const NON_COLOR_ATTRIBUTES = ['unit', 'category'];
+export const CHART_COLOR_ATTRIBUTES = CHART_ATTRIBUTES.filter(
+  (attr) => !NON_COLOR_ATTRIBUTES.includes(attr.value),
+);
+
 export const CUSTOM_PROJECTION_SETTINGS = {
   availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
   [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
@@ -92,33 +97,32 @@ export const generateCustomProjectionSettings = (
       return acc;
     }, [] as string[]);
 
-    chartIndicators = CHART_INDICATORS.filter(
-      (indicator) => !usedValues.includes(indicator.value),
-    );
-    chartAttributes = CHART_ATTRIBUTES.filter(
-      (attribute) => !usedValues.includes(attribute.value),
-    );
-    chartColorAttributes = CHART_COLOR_ATTRIBUTES.filter(
-      (attribute) => !usedValues.includes(attribute.value),
-    );
-  }
+  const filteredChartIndicators = CHART_INDICATORS.filter(
+    (indicator) => !usedValues.includes(indicator.value),
+  );
+  const filteredChartAttributes = CHART_ATTRIBUTES.filter(
+    (attribute) => !usedValues.includes(attribute.value),
+  );
+  const filteredChartColorAttributes = CHART_COLOR_ATTRIBUTES.filter(
+    (attribute) => !usedValues.includes(attribute.value),
+  );
 
   const settings: CustomProjectionSettingsType = {
     availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
     [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
-      vertical: chartIndicators,
-      color: chartColorAttributes,
+      vertical: filteredChartIndicators,
+      color: filteredChartColorAttributes,
     },
     [PROJECTION_VISUALIZATIONS.BAR_CHART]: {
-      vertical: chartIndicators,
-      color: chartColorAttributes,
+      vertical: filteredChartIndicators,
+      color: filteredChartColorAttributes,
     },
     [PROJECTION_VISUALIZATIONS.BUBBLE_CHART]: {
-      bubble: chartAttributes,
-      vertical: chartIndicators,
-      horizontal: chartIndicators,
-      color: chartColorAttributes,
-      size: chartIndicators,
+      bubble: filteredChartAttributes,
+      vertical: filteredChartIndicators,
+      horizontal: filteredChartIndicators,
+      color: filteredChartColorAttributes,
+      size: filteredChartIndicators,
     },
     [PROJECTION_VISUALIZATIONS.TABLE]: {
       vertical: chartIndicators,

--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -85,13 +85,12 @@ export const generateCustomProjectionSettings = (
 
   let chartIndicators = CHART_INDICATORS;
   let chartAttributes = CHART_ATTRIBUTES;
-  let chartColorAttributes = CHART_COLOR_ATTRIBUTES;
 
-  if (filters) {
-    const usedValues = filters.reduce((acc, filter) => {
+  const usedValues =
+    filters?.reduce((acc, filter) => {
       acc.push(...(filter.values as string[]));
       return acc;
-    }, [] as string[]);
+    }, [] as string[]) || [];
 
   const filteredChartIndicators = CHART_INDICATORS.filter(
     (indicator) => !usedValues.includes(indicator.value),


### PR DESCRIPTION
## Summary
  - Removed "Unit" and "Category" from the color (data breakdown) selector in the projections sandbox
  - These fields are filter-only and should not be available as color/breakdown options.
  - Created `CHART_COLOR_ATTRIBUTES` constant that excludes these fields, used for all `color` settings across line chart, bar chart, and bubble chart