### PR TITLE
feat: implement table view with dimension columns for projections sandbox

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -177,6 +177,61 @@ export class PostgresProjectionDataRepository
     return result[0]?.data;
   }
 
+  public async findProjectionTableData(
+    dataFilters: SearchFilterDTO[],
+    indicator: string,
+  ): Promise<CustomProjection> {
+    const baseQueryBuilder = this.dataSource
+      .getRepository(Projection)
+      .createQueryBuilder('projection')
+      .select('projectionData.year', 'year')
+      .addSelect('projectionData.value', 'value')
+      .addSelect('projection.scenario', 'scenario')
+      .addSelect('projection.technology', 'technology')
+      .addSelect('projection.technologyType', 'technology_type')
+      .addSelect('projection.country', 'country')
+      .addSelect('projection.category', 'category')
+      .addSelect('projection.unit', 'unit')
+      .innerJoin('projection.projectionData', 'projectionData')
+      .where('projection.type = :type', { type: indicator })
+      .orderBy('projectionData.year', 'ASC');
+
+    QueryBuilderUtils.applySearchFilters(baseQueryBuilder, dataFilters, {
+      alias: 'projection',
+      filterNameToFieldNameMap: PROJECTION_FILTER_NAME_TO_FIELD_NAME,
+    });
+
+    const finalQuery = `
+      SELECT
+        JSON_OBJECT_AGG(
+          unit,
+          unit_data
+        ) as data
+      FROM (
+        SELECT
+          unit,
+          JSON_AGG(
+            JSON_BUILD_OBJECT(
+              'year', year,
+              'value', value,
+              'scenario', ${this.getConditionalHumanizationSql('scenario', 'scenario')},
+              'technology', ${this.getConditionalHumanizationSql('technology', 'technology')},
+              'technologyType', ${this.getConditionalHumanizationSql('technology_type', 'technology-type')},
+              'country', ${this.getConditionalHumanizationSql('country', 'country')},
+              'category', category
+            )
+            ORDER BY year ASC
+          ) as unit_data
+        FROM (${baseQueryBuilder.getSql()}) as base_data
+        GROUP BY unit
+      ) as grouped_data
+    `;
+
+    const parameters = Object.values(baseQueryBuilder.getParameters()).flat();
+    const result = await this.dataSource.query(finalQuery, parameters);
+    return result[0]?.data || {};
+  }
+
   public async findSimpleProjectionCustomWidgetData(
     widgetVisualization: ProjectionVisualizationsType,
     dataFilters: SearchFilterDTO[],
@@ -320,10 +375,10 @@ export class PostgresProjectionDataRepository
       case PROJECTION_VISUALIZATIONS.TABLE:
         const tableSettings = (settings as { table: { vertical: string } })
           .table;
-        return this.findProjectionWidgetData([
-          ...dataFilters,
-          { name: 'type', operator: '=', values: [tableSettings.vertical] },
-        ]);
+        return this.findProjectionTableData(
+          dataFilters,
+          tableSettings.vertical,
+        );
       case PROJECTION_VISUALIZATIONS.LINE_CHART:
       case PROJECTION_VISUALIZATIONS.BAR_CHART:
         // Only aggregate 'others' in findSimpleProjectionCustomWidgetData

--- a/api/src/infrastructure/projection-data-repository.interface.ts
+++ b/api/src/infrastructure/projection-data-repository.interface.ts
@@ -24,6 +24,10 @@ export interface IProjectionDataRepository extends Repository<ProjectionData> {
     colorFieldName: string,
     dataFilters: SearchFilterDTO[],
   ): Promise<number>;
+  findProjectionTableData(
+    dataFilters: SearchFilterDTO[],
+    indicator: string,
+  ): Promise<CustomProjection>;
   previewProjectionCustomWidget(
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,

--- a/api/test/e2e/projections/custom-projection.spec.ts
+++ b/api/test/e2e/projections/custom-projection.spec.ts
@@ -76,6 +76,11 @@ describe('Custom Projection API', () => {
     expect(Array.isArray(firstProjectionDataForUnit)).toBe(true);
     expect(firstProjectionDataForUnit[0]).toHaveProperty('year');
     expect(firstProjectionDataForUnit[0]).toHaveProperty('value');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('scenario');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('technology');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('technologyType');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('country');
+    expect(firstProjectionDataForUnit[0]).toHaveProperty('category');
     expect(firstProjectionDataForUnit[0]).not.toHaveProperty('color');
     expect(firstProjectionDataForUnit[0]).not.toHaveProperty('vertical');
   });

--- a/shared/dto/projections/custom-projection.type.ts
+++ b/shared/dto/projections/custom-projection.type.ts
@@ -21,6 +21,11 @@ export type TableProjection = {
   [unit: string]: {
     year: number;
     value: number;
+    scenario: string;
+    technology: string;
+    technologyType: string;
+    country: string;
+    category: string;
   }[];
 };
 


### PR DESCRIPTION
## Summary
- Add new `findProjectionTableData` repository method that returns non-aggregated projection rows with dimension columns (scenario, technology, technologyType, country, category) instead of the previous year+value only response
- Update `TableProjection` type to include the new dimension fields
- Update e2e tests to verify the new table response shape