### PR TITLE
feat: save visualizations in projections sandbox

### DIFF
--- a/api/src/migrations/1774700000000-create-saved-projections-table.ts
+++ b/api/src/migrations/1774700000000-create-saved-projections-table.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSavedProjectionsTable1774700000000 implements MigrationInterface {
+  name = 'CreateSavedProjectionsTable1774700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "saved_projections" (
+        "id" SERIAL PRIMARY KEY,
+        "user_id" uuid REFERENCES "users"("id") ON DELETE CASCADE,
+        "name" character varying NOT NULL,
+        "settings" jsonb NOT NULL,
+        "data_filters" jsonb,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT now()
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "saved_projections"`);
+  }
+}

--- a/api/src/modules/projections/projections.module.ts
+++ b/api/src/modules/projections/projections.module.ts
@@ -3,10 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '@api/modules/auth/auth.module';
 import { SQLAdapter } from '@api/infrastructure/sql-adapter';
 import { ProjectionsController } from '@api/modules/projections/projections.controller';
+import { SavedProjectionsController } from '@api/modules/projections/saved-projections.controller';
 import { Projection } from '@shared/dto/projections/projection.entity';
 import { ProjectionData } from '@shared/dto/projections/projection-data.entity';
 import { ProjectionWidget } from '@shared/dto/projections/projection-widget.entity';
+import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
 import { ProjectionsService } from '@api/modules/projections/projections.service';
+import { SavedProjectionService } from '@api/modules/projections/saved-projections.service';
 import { PostgresProjectionDataRepository } from '@api/infrastructure/postgres-projection-data.repository';
 import { ProjectionDataRepository } from '@api/infrastructure/projection-data-repository.interface';
 import { ProjectionFilter } from '@shared/dto/projections/projection-filter.entity';
@@ -20,6 +23,7 @@ import { ProjectionType } from '@shared/dto/projections/projection-type.entity';
       ProjectionWidget,
       ProjectionFilter,
       ProjectionType,
+      SavedProjection,
     ]),
     forwardRef(() => AuthModule),
   ],
@@ -30,7 +34,8 @@ import { ProjectionType } from '@shared/dto/projections/projection-type.entity';
       useClass: PostgresProjectionDataRepository,
     },
     ProjectionsService,
+    SavedProjectionService,
   ],
-  controllers: [ProjectionsController],
+  controllers: [ProjectionsController, SavedProjectionsController],
 })
 export class ProjectionsModule {}

--- a/api/src/modules/projections/saved-projections.controller.ts
+++ b/api/src/modules/projections/saved-projections.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common';
 import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
-import { usersContract as c } from '@shared/contracts/users.contract';
+import { savedProjectionsContract as c } from '@shared/contracts/saved-projections.contract';
 import { ControllerResponse } from '@api/types/controller.type';
 import { SavedProjectionService } from '@api/modules/projections/saved-projections.service';
 import { AuthorizeByUserIdParam } from '@api/decorators/authorize';

--- a/api/src/modules/projections/saved-projections.controller.ts
+++ b/api/src/modules/projections/saved-projections.controller.ts
@@ -1,0 +1,77 @@
+import { Controller } from '@nestjs/common';
+import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
+import { usersContract as c } from '@shared/contracts/users.contract';
+import { ControllerResponse } from '@api/types/controller.type';
+import { SavedProjectionService } from '@api/modules/projections/saved-projections.service';
+import { AuthorizeByUserIdParam } from '@api/decorators/authorize';
+
+@Controller()
+export class SavedProjectionsController {
+  public constructor(
+    private readonly savedProjectionService: SavedProjectionService,
+  ) {}
+
+  @AuthorizeByUserIdParam()
+  @TsRestHandler(c.searchSavedProjections)
+  public async searchSavedProjections(): Promise<ControllerResponse> {
+    return tsRestHandler(
+      c.searchSavedProjections,
+      async ({ params, query }) => {
+        const data = await this.savedProjectionService.searchSavedProjections(
+          params.userId,
+          query,
+        );
+        return { body: data, status: 200 };
+      },
+    );
+  }
+
+  @AuthorizeByUserIdParam()
+  @TsRestHandler(c.findSavedProjection)
+  public async findSavedProjection(): Promise<ControllerResponse> {
+    return tsRestHandler(c.findSavedProjection, async ({ params }) => {
+      const { userId, id } = params;
+      const data = await this.savedProjectionService.findSavedProjectionById(
+        userId,
+        id,
+      );
+      return { body: { data }, status: 200 };
+    });
+  }
+
+  @AuthorizeByUserIdParam()
+  @TsRestHandler(c.createSavedProjection)
+  public async createSavedProjection(): Promise<ControllerResponse> {
+    return tsRestHandler(c.createSavedProjection, async ({ params, body }) => {
+      const data = await this.savedProjectionService.createSavedProjection(
+        params.userId,
+        body,
+      );
+      return { body: { data }, status: 201 };
+    });
+  }
+
+  @AuthorizeByUserIdParam()
+  @TsRestHandler(c.updateSavedProjection)
+  public async updateSavedProjection(): Promise<ControllerResponse> {
+    return tsRestHandler(c.updateSavedProjection, async ({ params, body }) => {
+      const { userId, id } = params;
+      const data = await this.savedProjectionService.updateSavedProjection(
+        userId,
+        id,
+        body,
+      );
+      return { body: { data }, status: 200 };
+    });
+  }
+
+  @AuthorizeByUserIdParam()
+  @TsRestHandler(c.deleteSavedProjection)
+  public async deleteSavedProjection(): Promise<ControllerResponse> {
+    return tsRestHandler(c.deleteSavedProjection, async ({ params }) => {
+      const { userId, id } = params;
+      await this.savedProjectionService.deleteSavedProjection(userId, id);
+      return { body: null, status: 204 };
+    });
+  }
+}

--- a/api/src/modules/projections/saved-projections.service.ts
+++ b/api/src/modules/projections/saved-projections.service.ts
@@ -1,0 +1,130 @@
+import { AppBaseService } from '@api/utils/app-base.service';
+import { AppInfoDTO } from '@api/utils/info.dto';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ApiPaginationResponse } from '@shared/dto/global/api-response.dto';
+import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
+import {
+  CreateSavedProjectionDTO,
+  UpdateSavedProjectionDTO,
+} from '@shared/dto/projections/saved-projection.dto';
+import { FetchSpecification } from 'nestjs-base-service';
+import { DeepPartial, Repository, SelectQueryBuilder } from 'typeorm';
+
+@Injectable()
+export class SavedProjectionService extends AppBaseService<
+  SavedProjection,
+  CreateSavedProjectionDTO,
+  UpdateSavedProjectionDTO,
+  AppInfoDTO
+> {
+  public constructor(
+    protected readonly logger: Logger,
+    @InjectRepository(SavedProjection)
+    private savedProjectionRepository: Repository<SavedProjection>,
+  ) {
+    super(savedProjectionRepository, 'saved-projection', 'saved-projections');
+  }
+
+  public async searchSavedProjections(
+    userId: string,
+    fetchSpecification: FetchSpecification,
+  ): Promise<ApiPaginationResponse<SavedProjection>> {
+    return this.findAllPaginated(fetchSpecification, { userId });
+  }
+
+  public async extendFindAllQuery(
+    query: SelectQueryBuilder<SavedProjection>,
+    fetchSpecification: Record<string, unknown>,
+  ) {
+    if (fetchSpecification.userId) {
+      query.where(`${this.alias}.user.id = :userId`, {
+        userId: fetchSpecification.userId,
+      });
+    }
+    return query;
+  }
+
+  public async findSavedProjectionById(
+    userId: string,
+    id: number,
+  ): Promise<SavedProjection> {
+    const savedProjection = await this.savedProjectionRepository.findOne({
+      where: {
+        id,
+        user: { id: userId },
+      },
+    });
+
+    if (savedProjection === null) {
+      throw new NotFoundException('SavedProjection not found');
+    }
+    return savedProjection;
+  }
+
+  public async createSavedProjection(
+    userId: string,
+    params: CreateSavedProjectionDTO,
+  ): Promise<SavedProjection> {
+    const savedProjection: DeepPartial<SavedProjection> = {
+      name: params.name,
+      user: { id: userId },
+      settings: params.settings,
+      dataFilters: params.dataFilters,
+    };
+    return this.savedProjectionRepository.save(savedProjection);
+  }
+
+  public async updateSavedProjection(
+    userId: string,
+    id: number,
+    params: UpdateSavedProjectionDTO,
+  ): Promise<SavedProjection> {
+    const savedProjection = await this.savedProjectionRepository.findOneBy({
+      id,
+      user: { id: userId },
+    });
+    if (savedProjection === null) {
+      const exception = new NotFoundException('SavedProjection not found');
+      this.logger.error(
+        `SavedProjection with id ${id} not found`,
+        null,
+        exception.stack,
+      );
+      throw exception;
+    }
+
+    if (params.name !== undefined) {
+      savedProjection.name = params.name;
+    }
+    if (params.settings !== undefined) {
+      savedProjection.settings = params.settings;
+    }
+    if (params.dataFilters !== undefined) {
+      savedProjection.dataFilters = params.dataFilters;
+    }
+
+    return this.savedProjectionRepository.save(savedProjection);
+  }
+
+  public async deleteSavedProjection(
+    userId: string,
+    id: number,
+    info?: AppInfoDTO,
+  ) {
+    const result = await this.savedProjectionRepository.delete({
+      id,
+      user: { id: userId },
+    });
+
+    if (result.affected === 0) {
+      const exception = new NotFoundException('SavedProjection not found');
+      this.logger.error(
+        `SavedProjection with id ${id} for user ${info?.authenticatedUser?.id} not found`,
+        null,
+        exception.stack,
+      );
+      throw exception;
+    }
+  }
+}

--- a/shared/contracts/index.ts
+++ b/shared/contracts/index.ts
@@ -7,6 +7,7 @@ import { sectionContract } from './sections.contract';
 import { widgetsContract } from '@shared/contracts/base-widgets.contract';
 import { pageFiltersContract } from '@shared/contracts/page-filters.contract';
 import { projectionsContract } from '@shared/contracts/projections.contract';
+import { savedProjectionsContract } from '@shared/contracts/saved-projections.contract';
 
 const c = initContract();
 
@@ -17,6 +18,7 @@ export const router = c.router({
   sections: sectionContract,
   widgets: widgetsContract,
   projections: projectionsContract,
+  savedProjections: savedProjectionsContract,
   pageFilter: pageFiltersContract,
 });
 

--- a/shared/contracts/saved-projections.contract.ts
+++ b/shared/contracts/saved-projections.contract.ts
@@ -1,0 +1,76 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import { JSONAPIError } from '@shared/dto/errors/json-api.error';
+import {
+  ApiPaginationResponse,
+  ApiResponse,
+} from '@shared/dto/global/api-response.dto';
+import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
+import {
+  CreateSavedProjectionSchema,
+  UpdateSavedProjectionSchema,
+} from '@shared/schemas/saved-projection.schema';
+import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
+
+const contract = initContract();
+export const savedProjectionsContract = contract.router({
+  searchSavedProjections: {
+    method: 'GET',
+    path: '/users/:userId/saved-projections',
+    pathParams: z.object({ userId: z.string().uuid() }),
+    query: generateEntityQuerySchema(SavedProjection),
+    responses: {
+      200: contract.type<ApiPaginationResponse<SavedProjection>>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  findSavedProjection: {
+    method: 'GET',
+    path: '/users/:userId/saved-projections/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    responses: {
+      200: contract.type<ApiResponse<SavedProjection>>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  createSavedProjection: {
+    method: 'POST',
+    path: '/users/:userId/saved-projections',
+    pathParams: z.object({ userId: z.string().uuid() }),
+    body: CreateSavedProjectionSchema,
+    responses: {
+      201: contract.type<ApiResponse<SavedProjection>>(),
+      400: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  updateSavedProjection: {
+    method: 'PATCH',
+    path: '/users/:userId/saved-projections/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    body: UpdateSavedProjectionSchema,
+    responses: {
+      200: contract.type<ApiResponse<SavedProjection>>(),
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  deleteSavedProjection: {
+    method: 'DELETE',
+    path: '/users/:userId/saved-projections/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    body: null,
+    responses: {
+      204: contract.type<null>(),
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+});

--- a/shared/contracts/users.contract.ts
+++ b/shared/contracts/users.contract.ts
@@ -15,6 +15,11 @@ import {
   CreateCustomWidgetSchema,
   UpdateCustomWidgetSchema,
 } from '@shared/schemas/widget.schemas';
+import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
+import {
+  CreateSavedProjectionSchema,
+  UpdateSavedProjectionSchema,
+} from '@shared/schemas/saved-projection.schema';
 import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
 import { User } from '@shared/dto/users/user.entity';
 
@@ -171,6 +176,66 @@ export const usersContract = contract.router({
   deleteCustomWidget: {
     method: 'DELETE',
     path: '/users/:userId/widgets/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    body: null,
+    responses: {
+      204: contract.type<null>(),
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  // Saved Projections
+  searchSavedProjections: {
+    method: 'GET',
+    path: '/users/:userId/saved-projections',
+    pathParams: z.object({ userId: z.string().uuid() }),
+    query: generateEntityQuerySchema(SavedProjection),
+    responses: {
+      200: contract.type<ApiPaginationResponse<SavedProjection>>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  findSavedProjection: {
+    method: 'GET',
+    path: '/users/:userId/saved-projections/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    responses: {
+      200: contract.type<ApiResponse<SavedProjection>>(),
+      401: contract.type<JSONAPIError>(),
+      403: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  createSavedProjection: {
+    method: 'POST',
+    path: '/users/:userId/saved-projections',
+    pathParams: z.object({ userId: z.string().uuid() }),
+    body: CreateSavedProjectionSchema,
+    responses: {
+      201: contract.type<ApiResponse<SavedProjection>>(),
+      400: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  updateSavedProjection: {
+    method: 'PATCH',
+    path: '/users/:userId/saved-projections/:id',
+    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
+    body: UpdateSavedProjectionSchema,
+    responses: {
+      200: contract.type<ApiResponse<SavedProjection>>(),
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+  },
+  deleteSavedProjection: {
+    method: 'DELETE',
+    path: '/users/:userId/saved-projections/:id',
     pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
     body: null,
     responses: {

--- a/shared/contracts/users.contract.ts
+++ b/shared/contracts/users.contract.ts
@@ -15,11 +15,6 @@ import {
   CreateCustomWidgetSchema,
   UpdateCustomWidgetSchema,
 } from '@shared/schemas/widget.schemas';
-import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
-import {
-  CreateSavedProjectionSchema,
-  UpdateSavedProjectionSchema,
-} from '@shared/schemas/saved-projection.schema';
 import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
 import { User } from '@shared/dto/users/user.entity';
 
@@ -176,66 +171,6 @@ export const usersContract = contract.router({
   deleteCustomWidget: {
     method: 'DELETE',
     path: '/users/:userId/widgets/:id',
-    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
-    body: null,
-    responses: {
-      204: contract.type<null>(),
-      400: contract.type<JSONAPIError>(),
-      404: contract.type<JSONAPIError>(),
-      500: contract.type<JSONAPIError>(),
-    },
-  },
-  // Saved Projections
-  searchSavedProjections: {
-    method: 'GET',
-    path: '/users/:userId/saved-projections',
-    pathParams: z.object({ userId: z.string().uuid() }),
-    query: generateEntityQuerySchema(SavedProjection),
-    responses: {
-      200: contract.type<ApiPaginationResponse<SavedProjection>>(),
-      401: contract.type<JSONAPIError>(),
-      403: contract.type<JSONAPIError>(),
-      500: contract.type<JSONAPIError>(),
-    },
-  },
-  findSavedProjection: {
-    method: 'GET',
-    path: '/users/:userId/saved-projections/:id',
-    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
-    responses: {
-      200: contract.type<ApiResponse<SavedProjection>>(),
-      401: contract.type<JSONAPIError>(),
-      403: contract.type<JSONAPIError>(),
-      404: contract.type<JSONAPIError>(),
-      500: contract.type<JSONAPIError>(),
-    },
-  },
-  createSavedProjection: {
-    method: 'POST',
-    path: '/users/:userId/saved-projections',
-    pathParams: z.object({ userId: z.string().uuid() }),
-    body: CreateSavedProjectionSchema,
-    responses: {
-      201: contract.type<ApiResponse<SavedProjection>>(),
-      400: contract.type<JSONAPIError>(),
-      500: contract.type<JSONAPIError>(),
-    },
-  },
-  updateSavedProjection: {
-    method: 'PATCH',
-    path: '/users/:userId/saved-projections/:id',
-    pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
-    body: UpdateSavedProjectionSchema,
-    responses: {
-      200: contract.type<ApiResponse<SavedProjection>>(),
-      400: contract.type<JSONAPIError>(),
-      404: contract.type<JSONAPIError>(),
-      500: contract.type<JSONAPIError>(),
-    },
-  },
-  deleteSavedProjection: {
-    method: 'DELETE',
-    path: '/users/:userId/saved-projections/:id',
     pathParams: z.object({ userId: z.string().uuid(), id: z.coerce.number() }),
     body: null,
     responses: {

--- a/shared/dto/projections/saved-projection.dto.ts
+++ b/shared/dto/projections/saved-projection.dto.ts
@@ -1,0 +1,12 @@
+import {
+  CreateSavedProjectionSchema,
+  UpdateSavedProjectionSchema,
+} from '@shared/schemas/saved-projection.schema';
+import { z } from 'zod';
+
+export type CreateSavedProjectionDTO = z.infer<
+  typeof CreateSavedProjectionSchema
+>;
+export type UpdateSavedProjectionDTO = z.infer<
+  typeof UpdateSavedProjectionSchema
+>;

--- a/shared/dto/projections/saved-projection.entity.ts
+++ b/shared/dto/projections/saved-projection.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  PrimaryGeneratedColumn,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { type CustomProjectionSettingsSchemaType } from '@shared/schemas/custom-projection-settings.schema';
+import { type SearchFilterDTO } from '@shared/dto/global/search-filters';
+
+@Entity('saved_projections')
+export class SavedProjection {
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @ManyToOne(() => User, (user: User) => user.savedProjections, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column()
+  name: string;
+
+  @Column('jsonb')
+  settings: CustomProjectionSettingsSchemaType;
+
+  @Column('jsonb', { name: 'data_filters', nullable: true })
+  dataFilters: SearchFilterDTO[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/shared/dto/projections/saved-projection.entity.ts
+++ b/shared/dto/projections/saved-projection.entity.ts
@@ -16,7 +16,7 @@ export class SavedProjection {
   @PrimaryGeneratedColumn('increment')
   id: number;
 
-  @ManyToOne(() => User, (user: User) => user.savedProjections, {
+  @ManyToOne(() => User, {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'user_id' })

--- a/shared/dto/users/user.entity.ts
+++ b/shared/dto/users/user.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
 import { CustomWidget } from '../widgets/custom-widget.entity';
+import { SavedProjection } from '../projections/saved-projection.entity';
 
 @Entity({ name: 'users' })
 export class User {
@@ -25,4 +26,7 @@ export class User {
 
   @OneToMany(() => CustomWidget, (customWidget) => customWidget.user)
   customWidgets: CustomWidget[];
+
+  @OneToMany(() => SavedProjection, (sp) => sp.user)
+  savedProjections: SavedProjection[];
 }

--- a/shared/dto/users/user.entity.ts
+++ b/shared/dto/users/user.entity.ts
@@ -7,7 +7,6 @@ import {
 } from 'typeorm';
 import { Exclude } from 'class-transformer';
 import { CustomWidget } from '../widgets/custom-widget.entity';
-import { SavedProjection } from '../projections/saved-projection.entity';
 
 @Entity({ name: 'users' })
 export class User {
@@ -27,6 +26,4 @@ export class User {
   @OneToMany(() => CustomWidget, (customWidget) => customWidget.user)
   customWidgets: CustomWidget[];
 
-  @OneToMany(() => SavedProjection, (sp) => sp.user)
-  savedProjections: SavedProjection[];
 }

--- a/shared/lib/db-entities.ts
+++ b/shared/lib/db-entities.ts
@@ -13,6 +13,7 @@ import { ProjectionData } from '@shared/dto/projections/projection-data.entity';
 import { ProjectionFilter } from '@shared/dto/projections/projection-filter.entity';
 import { ProjectionType } from '@shared/dto/projections/projection-type.entity';
 import { ProjectionWidget } from '@shared/dto/projections/projection-widget.entity';
+import { SavedProjection } from '@shared/dto/projections/saved-projection.entity';
 import { ConfigurationParams } from '@shared/dto/global/configuration-params';
 
 export const DB_ENTITIES: MixedList<Function | string | EntitySchema> = [
@@ -30,5 +31,6 @@ export const DB_ENTITIES: MixedList<Function | string | EntitySchema> = [
   ProjectionWidget,
   ProjectionFilter,
   ProjectionType,
+  SavedProjection,
   ConfigurationParams,
 ];

--- a/shared/schemas/saved-projection.schema.ts
+++ b/shared/schemas/saved-projection.schema.ts
@@ -1,0 +1,15 @@
+import { CustomProjectionSettingsSchema } from '@shared/schemas/custom-projection-settings.schema';
+import { SearchFilterSchema } from '@shared/schemas/search-filters.schema';
+import { z } from 'zod';
+
+export const CreateSavedProjectionSchema = z.object({
+  name: z.string().min(1),
+  settings: CustomProjectionSettingsSchema,
+  dataFilters: z.array(SearchFilterSchema).optional(),
+});
+
+export const UpdateSavedProjectionSchema = z.object({
+  name: z.string().min(1).optional(),
+  settings: CustomProjectionSettingsSchema.optional(),
+  dataFilters: z.array(SearchFilterSchema).optional(),
+});


### PR DESCRIPTION
## Summary
- Add `saved_projections` table with JSONB columns for storing visualization settings and data filters
- Add CRUD endpoints under `/users/:userId/saved-projections` (create, list, get, update, delete)
- Follow existing `CustomWidget` pattern: entity, Zod schemas, ts-rest contract, service, controller
- All endpoints protected with JWT auth and user ownership verification via `@AuthorizeByUserIdParam()`

## Test plan
- [x] API build passes
- [x] Linter and formatter pass
- [x] Manual API testing: full CRUD cycle (201, 200, 200, 200, 204, 404 after delete)
- [x] Authorization: cross-user access returns 403, anonymous access returns 401