### PR TITLE
feat: conditionally include othersAggregation in projection settings based on data

### DIFF
--- a/api/src/infrastructure/postgres-projection-data.repository.ts
+++ b/api/src/infrastructure/postgres-projection-data.repository.ts
@@ -89,6 +89,26 @@ export class PostgresProjectionDataRepository
     // return result;
   }
 
+  public async countDistinctColorValues(
+    colorFieldName: string,
+    dataFilters: SearchFilterDTO[],
+  ): Promise<number> {
+    const fieldName =
+      PROJECTION_FILTER_NAME_TO_FIELD_NAME[colorFieldName] || colorFieldName;
+    const queryBuilder = this.dataSource
+      .getRepository(Projection)
+      .createQueryBuilder('projection')
+      .select(`COUNT(DISTINCT projection.${fieldName})`, 'count');
+
+    QueryBuilderUtils.applySearchFilters(queryBuilder, dataFilters, {
+      alias: 'projection',
+      filterNameToFieldNameMap: PROJECTION_FILTER_NAME_TO_FIELD_NAME,
+    });
+
+    const result = await queryBuilder.getRawOne();
+    return parseInt(result?.count || '0', 10);
+  }
+
   public async addDataToProjectionsWidgets(
     projectionWidgets: ProjectionWidget[],
     dataFilters: SearchFilterDTO[],

--- a/api/src/infrastructure/projection-data-repository.interface.ts
+++ b/api/src/infrastructure/projection-data-repository.interface.ts
@@ -20,6 +20,10 @@ export interface IProjectionDataRepository extends Repository<ProjectionData> {
     dataFilters: SearchFilterDTO[],
   ): Promise<void>;
   findProjectionWidgetData(dataFilters: SearchFilterDTO[]): Promise<any>;
+  countDistinctColorValues(
+    colorFieldName: string,
+    dataFilters: SearchFilterDTO[],
+  ): Promise<number>;
   previewProjectionCustomWidget(
     dataFilters: SearchFilterDTO[],
     settings: CustomProjectionSettingsType,

--- a/api/src/modules/projections/projections.controller.ts
+++ b/api/src/modules/projections/projections.controller.ts
@@ -33,7 +33,8 @@ export class ProjectionsController {
   @TsRestHandler(c.getCustomProjectionSettings)
   public async getCustomProjectionSettings(): Promise<ControllerResponse> {
     return tsRestHandler(c.getCustomProjectionSettings, async ({ query }) => {
-      const data = this.projectionsService.getCustomProjectionSettings(query);
+      const data =
+        await this.projectionsService.getCustomProjectionSettings(query);
 
       return { body: { data }, status: 200 };
     });

--- a/api/src/modules/projections/projections.service.ts
+++ b/api/src/modules/projections/projections.service.ts
@@ -55,10 +55,26 @@ export class ProjectionsService extends AppBaseService<
     );
   }
 
-  public getCustomProjectionSettings(
+  public async getCustomProjectionSettings(
     query: SearchFiltersDTO,
-  ): CustomProjectionSettingsType {
-    return generateCustomProjectionSettings(query);
+  ): Promise<CustomProjectionSettingsType> {
+    const { filters, dataFilters = [] } = query;
+    const colorFilter = filters?.find((f) => f.name === 'color');
+    const colorAttribute = colorFilter?.values?.[0] as string | undefined;
+
+    let includeOthersAggregation = true;
+    if (colorAttribute) {
+      const distinctCount =
+        await this.projectionDataRepository.countDistinctColorValues(
+          colorAttribute,
+          dataFilters,
+        );
+      includeOthersAggregation = distinctCount > 9;
+    } else {
+      includeOthersAggregation = false;
+    }
+
+    return generateCustomProjectionSettings(query, includeOthersAggregation);
   }
 
   public async getProjectionsFilters(

--- a/api/test/e2e/projections/custom-projection.spec.ts
+++ b/api/test/e2e/projections/custom-projection.spec.ts
@@ -249,10 +249,32 @@ describe('Custom Projection API', () => {
   });
 
   describe('Others Aggregation', () => {
-    test(`${c.getCustomProjectionSettings.path} should include othersAggregation options in settings`, async () => {
+    test(`${c.getCustomProjectionSettings.path} should not include othersAggregation when no color attribute is selected`, async () => {
       const res = await testManager
         .request()
         .get(c.getCustomProjectionSettings.path);
+
+      expect(res.status).toBe(200);
+      expect(res.body?.data.othersAggregation).toBeUndefined();
+    });
+
+    test(`${c.getCustomProjectionSettings.path} should not include othersAggregation when color attribute has few distinct values`, async () => {
+      const res = await testManager
+        .request()
+        .get(
+          `${c.getCustomProjectionSettings.path}?filters[0][name]=color&filters[0][operator]==&filters[0][values][0]=scenario`,
+        );
+
+      expect(res.status).toBe(200);
+      expect(res.body?.data.othersAggregation).toBeUndefined();
+    });
+
+    test(`${c.getCustomProjectionSettings.path} should include othersAggregation when color attribute has many distinct values`, async () => {
+      const res = await testManager
+        .request()
+        .get(
+          `${c.getCustomProjectionSettings.path}?filters[0][name]=color&filters[0][operator]==&filters[0][values][0]=country`,
+        );
 
       expect(res.status).toBe(200);
       expect(res.body?.data.othersAggregation).toStrictEqual([

--- a/shared/dto/projections/custom-projection-settings.ts
+++ b/shared/dto/projections/custom-projection-settings.ts
@@ -28,7 +28,6 @@ export const OTHERS_AGGREGATION_OPTIONS = [
 
 export const CUSTOM_PROJECTION_SETTINGS = {
   availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
-  othersAggregation: OTHERS_AGGREGATION_OPTIONS,
   [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
     vertical: CHART_INDICATORS,
     color: CHART_COLOR_ATTRIBUTES,
@@ -54,7 +53,7 @@ type AxisSettingsType = { value: string; label: string }[];
 
 export type CustomProjectionSettingsType = {
   availableVisualizations: typeof AVAILABLE_PROJECTION_VISUALIZATIONS;
-  othersAggregation: typeof OTHERS_AGGREGATION_OPTIONS;
+  othersAggregation?: typeof OTHERS_AGGREGATION_OPTIONS;
   [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
     vertical: AxisSettingsType;
     color: AxisSettingsType;
@@ -79,47 +78,57 @@ export type CustomProjectionSettingsType = {
 // Workaround to be able to generate custom projection settings removing selected indicator to prevent visualizing the same indicator in multiple axes
 export const generateCustomProjectionSettings = (
   query: SearchFiltersDTO = {},
-) => {
+  includeOthersAggregation = true,
+): CustomProjectionSettingsType => {
   const { filters } = query;
 
-  if (!filters) return CUSTOM_PROJECTION_SETTINGS;
+  let chartIndicators = CHART_INDICATORS;
+  let chartAttributes = CHART_ATTRIBUTES;
+  let chartColorAttributes = CHART_COLOR_ATTRIBUTES;
 
-  const usedValues = filters.reduce((acc, filter) => {
-    acc.push(...(filter.values as string[]));
-    return acc;
-  }, [] as string[]);
+  if (filters) {
+    const usedValues = filters.reduce((acc, filter) => {
+      acc.push(...(filter.values as string[]));
+      return acc;
+    }, [] as string[]);
 
-  const filteredChartIndicators = CHART_INDICATORS.filter(
-    (indicator) => !usedValues.includes(indicator.value),
-  );
-  const filteredChartAttributes = CHART_ATTRIBUTES.filter(
-    (attribute) => !usedValues.includes(attribute.value),
-  );
-  const filteredChartColorAttributes = CHART_COLOR_ATTRIBUTES.filter(
-    (attribute) => !usedValues.includes(attribute.value),
-  );
+    chartIndicators = CHART_INDICATORS.filter(
+      (indicator) => !usedValues.includes(indicator.value),
+    );
+    chartAttributes = CHART_ATTRIBUTES.filter(
+      (attribute) => !usedValues.includes(attribute.value),
+    );
+    chartColorAttributes = CHART_COLOR_ATTRIBUTES.filter(
+      (attribute) => !usedValues.includes(attribute.value),
+    );
+  }
 
-  return {
+  const settings: CustomProjectionSettingsType = {
     availableVisualizations: AVAILABLE_PROJECTION_VISUALIZATIONS,
-    othersAggregation: OTHERS_AGGREGATION_OPTIONS,
     [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
-      vertical: filteredChartIndicators,
-      color: filteredChartColorAttributes,
+      vertical: chartIndicators,
+      color: chartColorAttributes,
     },
     [PROJECTION_VISUALIZATIONS.BAR_CHART]: {
-      vertical: filteredChartIndicators,
-      color: filteredChartColorAttributes,
+      vertical: chartIndicators,
+      color: chartColorAttributes,
     },
     [PROJECTION_VISUALIZATIONS.BUBBLE_CHART]: {
-      bubble: filteredChartAttributes,
-      vertical: filteredChartIndicators,
-      horizontal: filteredChartIndicators,
-      color: filteredChartColorAttributes,
-      size: filteredChartIndicators,
+      bubble: chartAttributes,
+      vertical: chartIndicators,
+      horizontal: chartIndicators,
+      color: chartColorAttributes,
+      size: chartIndicators,
     },
     [PROJECTION_VISUALIZATIONS.TABLE]: {
-      vertical: filteredChartIndicators,
-      color: filteredChartAttributes,
+      vertical: chartIndicators,
+      color: chartAttributes,
     },
-  } as CustomProjectionSettingsType;
+  };
+
+  if (includeOthersAggregation) {
+    settings.othersAggregation = OTHERS_AGGREGATION_OPTIONS;
+  }
+
+  return settings;
 };


### PR DESCRIPTION
## Summary
- The settings endpoint (`GET /projections/custom-widget/settings`) now only includes `othersAggregation` options when the selected color attribute has more than 9 distinct values in the database
- Previously, `othersAggregation` was always returned as a static field regardless of whether the data would produce "Others" entries
- Added `countDistinctColorValues` repository method to query distinct values for a given dimension
- Made `getCustomProjectionSettings` service method async to support the DB query