### PR TITLE
feat: download widget data as CSV (Survey + Projections)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -43,6 +43,7 @@
     "class-transformer": "catalog:",
     "class-validator": "catalog:",
     "config": "4.4.1",
+    "csv-stringify": "6.7.0",
     "jsonapi-serializer": "3.6.9",
     "lodash": "catalog:",
     "nodemailer": "8.0.5",

--- a/api/src/modules/projections/projections.controller.ts
+++ b/api/src/modules/projections/projections.controller.ts
@@ -1,4 +1,5 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Res } from '@nestjs/common';
+import type { Response } from 'express';
 import { tsRestHandler, TsRestHandler } from '@ts-rest/nest';
 import { projectionsContract as c } from '@shared/contracts/projections.contract';
 import { ControllerResponse } from '@api/types/controller.type';
@@ -48,6 +49,41 @@ export class ProjectionsController {
         await this.projectionsService.generateCustomProjection(query);
 
       return { body: { data }, status: 200 };
+    });
+  }
+
+  @Public()
+  @TsRestHandler(c.exportProjectionWidget)
+  public async exportProjectionWidget(
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<ControllerResponse> {
+    return tsRestHandler(
+      c.exportProjectionWidget,
+      async ({ params: { id }, query }) => {
+        const { csv, filename } =
+          await this.projectionsService.exportProjectionWidgetCsv(id, query);
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${filename}"`,
+        );
+        return { body: csv, status: 200 };
+      },
+    );
+  }
+
+  @Public()
+  @TsRestHandler(c.exportCustomProjection)
+  public async exportCustomProjection(
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<ControllerResponse> {
+    return tsRestHandler(c.exportCustomProjection, async ({ query }) => {
+      const { csv, filename } =
+        await this.projectionsService.exportCustomProjectionCsv(query);
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${filename}"`,
+      );
+      return { body: csv, status: 200 };
     });
   }
 }

--- a/api/src/modules/projections/projections.service.ts
+++ b/api/src/modules/projections/projections.service.ts
@@ -1,7 +1,12 @@
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { AppBaseService } from '@api/utils/app-base.service';
 import { AppInfoDTO } from '@api/utils/info.dto';
-import { Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Projection } from '@shared/dto/projections/projection.entity';
@@ -23,6 +28,9 @@ import {
 } from '@shared/dto/projections/custom-projection-settings';
 import { CustomProjection } from '@shared/dto/projections/custom-projection.type';
 import { CustomProjectionSettingsSchemaType } from '@shared/schemas/custom-projection-settings.schema';
+import { NonExportableWidgetError } from '@api/modules/widgets/csv/widget-data.csv';
+import { serializeProjectionDataToCsv } from '@api/modules/widgets/csv/projection-data.csv';
+import { buildCsvFilename } from '@api/modules/widgets/csv/filename';
 @Injectable()
 export class ProjectionsService extends AppBaseService<
   Projection,
@@ -130,5 +138,61 @@ export class ProjectionsService extends AppBaseService<
       fetchSpecification.filters,
       { alias: 'projection' },
     );
+  }
+
+  public async exportProjectionWidgetCsv(
+    id: number,
+    query: SearchFiltersDTO,
+    now: Date = new Date(),
+  ): Promise<{ csv: string; filename: string }> {
+    const widget = await this.projectionWidgetsRepository.findOneBy({ id });
+    if (widget === null) {
+      throw new NotFoundException(`Projection widget with id ${id} not found`);
+    }
+
+    const { dataFilters = [] } = query;
+    await this.projectionDataRepository.addDataToProjectionsWidgets(
+      [widget],
+      dataFilters,
+    );
+
+    if (!widget.data || Object.keys(widget.data).length === 0) {
+      throw new BadRequestException('Projection widget has no data to export');
+    }
+
+    return this.wrapCsv(
+      () => serializeProjectionDataToCsv(widget.data),
+      widget.title,
+      now,
+    );
+  }
+
+  public async exportCustomProjectionCsv(
+    query: SearchFiltersDTO & CustomProjectionSettingsSchemaType,
+    now: Date = new Date(),
+  ): Promise<{ csv: string; filename: string }> {
+    const projection = await this.generateCustomProjection(query);
+    return this.wrapCsv(
+      () => serializeProjectionDataToCsv(projection),
+      'custom-projection',
+      now,
+    );
+  }
+
+  private wrapCsv(
+    serialize: () => string,
+    titleForFilename: string,
+    now: Date,
+  ): { csv: string; filename: string } {
+    try {
+      const csv = serialize();
+      const filename = buildCsvFilename(titleForFilename, now);
+      return { csv, filename };
+    } catch (error) {
+      if (error instanceof NonExportableWidgetError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
   }
 }

--- a/api/src/modules/widgets/csv/filename.spec.ts
+++ b/api/src/modules/widgets/csv/filename.spec.ts
@@ -1,0 +1,40 @@
+import { buildCsvFilename } from '@api/modules/widgets/csv/filename';
+
+describe('buildCsvFilename', () => {
+  const refDate = new Date('2026-04-13T10:30:00Z');
+
+  it('slugifies title and appends ISO date with .csv extension', () => {
+    expect(buildCsvFilename('Total Surveys', refDate)).toBe(
+      'total-surveys-2026-04-13.csv',
+    );
+  });
+
+  it('replaces punctuation and collapses repeated separators', () => {
+    expect(
+      buildCsvFilename('Adoption of Technology: by Country!', refDate),
+    ).toBe('adoption-of-technology-by-country-2026-04-13.csv');
+  });
+
+  it('strips accents from non-ASCII characters', () => {
+    expect(buildCsvFilename('Énergie & Agriculture', refDate)).toBe(
+      'energie-agriculture-2026-04-13.csv',
+    );
+  });
+
+  it('trims leading and trailing separators', () => {
+    expect(buildCsvFilename('  --Hello--  ', refDate)).toBe(
+      'hello-2026-04-13.csv',
+    );
+  });
+
+  it('falls back to "widget" when title slugifies to empty', () => {
+    expect(buildCsvFilename('***', refDate)).toBe('widget-2026-04-13.csv');
+    expect(buildCsvFilename('', refDate)).toBe('widget-2026-04-13.csv');
+  });
+
+  it('uses UTC date regardless of local timezone', () => {
+    // 2026-04-13 23:30 UTC — in some timezones this is already 2026-04-14 local.
+    const date = new Date('2026-04-13T23:30:00Z');
+    expect(buildCsvFilename('widget', date)).toBe('widget-2026-04-13.csv');
+  });
+});

--- a/api/src/modules/widgets/csv/filename.ts
+++ b/api/src/modules/widgets/csv/filename.ts
@@ -1,0 +1,21 @@
+export function buildCsvFilename(title: string, date: Date): string {
+  const slug = slugify(title);
+  const datePart = toUtcDateString(date);
+  return `${slug || 'widget'}-${datePart}.csv`;
+}
+
+function slugify(input: string): string {
+  return input
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function toUtcDateString(date: Date): string {
+  const yyyy = date.getUTCFullYear().toString().padStart(4, '0');
+  const mm = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const dd = date.getUTCDate().toString().padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/api/src/modules/widgets/csv/projection-data.csv.spec.ts
+++ b/api/src/modules/widgets/csv/projection-data.csv.spec.ts
@@ -1,0 +1,106 @@
+import { serializeProjectionDataToCsv } from '@api/modules/widgets/csv/projection-data.csv';
+import {
+  BreakdownProjection,
+  BubbleProjection,
+  SimpleProjection,
+  TableProjection,
+} from '@shared/dto/projections/custom-projection.type';
+
+describe('serializeProjectionDataToCsv', () => {
+  it('serializes a simple projection (year/vertical/color per unit)', () => {
+    const data: SimpleProjection = {
+      EUR: [
+        { year: 2025, vertical: 100, color: 'Solar' },
+        { year: 2026, vertical: 120, color: 'Solar' },
+      ],
+      USD: [{ year: 2025, vertical: 80, color: 'Wind' }],
+    };
+    expect(serializeProjectionDataToCsv(data)).toBe(
+      'unit,year,vertical,color\n' +
+        'EUR,2025,100,Solar\n' +
+        'EUR,2026,120,Solar\n' +
+        'USD,2025,80,Wind\n',
+    );
+  });
+
+  it('serializes a bubble projection', () => {
+    const data: BubbleProjection = {
+      MW: [
+        {
+          year: 2025,
+          bubble: 'Solar',
+          color: 'A',
+          vertical: 10,
+          horizontal: 5,
+          size: 2,
+        },
+      ],
+    };
+    expect(serializeProjectionDataToCsv(data)).toBe(
+      'unit,year,bubble,color,vertical,horizontal,size\n' +
+        'MW,2025,Solar,A,10,5,2\n',
+    );
+  });
+
+  it('serializes a table projection', () => {
+    const data: TableProjection = {
+      GWh: [
+        {
+          year: 2025,
+          value: 42,
+          scenario: 'S1',
+          technology: 'Solar',
+          technologyType: 'PV',
+          country: 'ES',
+          category: 'Renewable',
+        },
+      ],
+    };
+    expect(serializeProjectionDataToCsv(data)).toBe(
+      'unit,year,value,scenario,technology,technology_type,country,category\n' +
+        'GWh,2025,42,S1,Solar,PV,ES,Renewable\n',
+    );
+  });
+
+  it('serializes a breakdown projection in long format', () => {
+    const data: BreakdownProjection = {
+      GWh: [
+        {
+          label: 'Spain',
+          data: [{ label: 'Solar', value: 10, total: 10 }],
+        },
+        {
+          label: 'France',
+          data: [
+            { label: 'Solar', value: 5, total: 7 },
+            { label: 'Wind', value: 2, total: 7 },
+          ],
+        },
+      ],
+    };
+    expect(serializeProjectionDataToCsv(data)).toBe(
+      'unit,breakdown_label,label,value,total\n' +
+        'GWh,Spain,Solar,10,10\n' +
+        'GWh,France,Solar,5,7\n' +
+        'GWh,France,Wind,2,7\n',
+    );
+  });
+
+  it('escapes commas and quotes in string fields', () => {
+    const data: SimpleProjection = {
+      'MW, net': [{ year: 2025, vertical: 1, color: 'Solar "peak"' }],
+    };
+    expect(serializeProjectionDataToCsv(data)).toBe(
+      'unit,year,vertical,color\n' + '"MW, net",2025,1,"Solar ""peak"""\n',
+    );
+  });
+
+  it('throws when projection has no units with rows', () => {
+    expect(() => serializeProjectionDataToCsv({})).toThrow(
+      /cannot be exported/i,
+    );
+    expect(() => serializeProjectionDataToCsv({ EUR: [] })).toThrow(
+      /cannot be exported/i,
+    );
+  });
+});

--- a/api/src/modules/widgets/csv/projection-data.csv.ts
+++ b/api/src/modules/widgets/csv/projection-data.csv.ts
@@ -1,0 +1,98 @@
+import { stringify } from 'csv-stringify/sync';
+import { CustomProjection } from '@shared/dto/projections/custom-projection.type';
+import { ProjectionWidgetData } from '@shared/dto/projections/projection-widget.entity';
+import { NonExportableWidgetError } from '@api/modules/widgets/csv/widget-data.csv';
+
+type ProjectionRow = Record<string, unknown>;
+
+export type ProjectionLikeData = CustomProjection | ProjectionWidgetData;
+
+export function serializeProjectionDataToCsv(data: ProjectionLikeData): string {
+  const sampleRow = findFirstRow(data);
+  if (sampleRow === null) {
+    throw new NonExportableWidgetError('projection has no data');
+  }
+
+  if (isBreakdownRow(sampleRow)) {
+    return serializeBreakdown(data as Record<string, BreakdownGroup[]>);
+  }
+
+  const columns = inferFlatColumns(sampleRow);
+  const rows: ProjectionRow[] = [];
+  for (const [unit, unitRows] of Object.entries(data) as Array<
+    [string, unknown[]]
+  >) {
+    for (const row of unitRows as ProjectionRow[]) {
+      rows.push({ unit, ...renameKeys(row) });
+    }
+  }
+
+  return stringify(rows, {
+    header: true,
+    columns: ['unit', ...columns],
+  });
+}
+
+type BreakdownGroup = {
+  label: string;
+  data: Array<{ label: string; value: number; total: number }>;
+};
+
+function isBreakdownRow(row: unknown): row is BreakdownGroup {
+  return (
+    typeof row === 'object' &&
+    row !== null &&
+    'label' in row &&
+    'data' in row &&
+    Array.isArray((row as BreakdownGroup).data)
+  );
+}
+
+function findFirstRow(data: ProjectionLikeData): unknown | null {
+  for (const rows of Object.values(data)) {
+    if (Array.isArray(rows) && rows.length > 0) {
+      return rows[0];
+    }
+  }
+  return null;
+}
+
+function serializeBreakdown(data: Record<string, BreakdownGroup[]>): string {
+  const rows: ProjectionRow[] = [];
+  for (const [unit, groups] of Object.entries(data)) {
+    for (const group of groups) {
+      for (const row of group.data) {
+        rows.push({
+          unit,
+          breakdown_label: group.label,
+          label: row.label,
+          value: row.value,
+          total: row.total,
+        });
+      }
+    }
+  }
+  return stringify(rows, {
+    header: true,
+    columns: ['unit', 'breakdown_label', 'label', 'value', 'total'],
+  });
+}
+
+const KEY_RENAMES: Record<string, string> = {
+  technologyType: 'technology_type',
+};
+
+function renameKeys(row: ProjectionRow): ProjectionRow {
+  const renamed: ProjectionRow = {};
+  for (const [key, value] of Object.entries(row)) {
+    renamed[KEY_RENAMES[key] ?? key] = value;
+  }
+  return renamed;
+}
+
+function inferFlatColumns(sampleRow: unknown): string[] {
+  if (typeof sampleRow !== 'object' || sampleRow === null) {
+    return [];
+  }
+  return Object.keys(sampleRow).map((k) => KEY_RENAMES[k] ?? k);
+}

--- a/api/src/modules/widgets/csv/widget-data.csv.spec.ts
+++ b/api/src/modules/widgets/csv/widget-data.csv.spec.ts
@@ -1,0 +1,88 @@
+import { serializeWidgetDataToCsv } from '@api/modules/widgets/csv/widget-data.csv';
+import { WidgetData } from '@shared/dto/widgets/base-widget-data.interface';
+
+describe('serializeWidgetDataToCsv', () => {
+  it('serializes a counter (single_value) widget', () => {
+    const data: WidgetData = { counter: { value: 3, total: 5 } };
+    expect(serializeWidgetDataToCsv(data)).toBe('value,total\n3,5\n');
+  });
+
+  it('serializes a chart widget (bar/pie/area)', () => {
+    const data: WidgetData = {
+      chart: [
+        { label: 'Agriculture', value: 2, total: 5 },
+        { label: 'Forestry', value: 3, total: 5 },
+      ],
+    };
+    expect(serializeWidgetDataToCsv(data)).toBe(
+      'label,value,total\nAgriculture,2,5\nForestry,3,5\n',
+    );
+  });
+
+  it('serializes a map widget', () => {
+    const data: WidgetData = {
+      map: [
+        { country: 'Belgium', value: 40 },
+        { country: 'Spain', value: 60 },
+      ],
+    };
+    expect(serializeWidgetDataToCsv(data)).toBe(
+      'country,value\nBelgium,40\nSpain,60\n',
+    );
+  });
+
+  it('serializes a breakdown widget in long format', () => {
+    const data: WidgetData = {
+      breakdown: [
+        {
+          label: 'Austria',
+          data: [{ label: 'Forestry', value: 1, total: 1 }],
+        },
+        {
+          label: 'Belgium',
+          data: [
+            { label: 'Agriculture', value: 2, total: 2 },
+            { label: 'Forestry', value: 1, total: 2 },
+          ],
+        },
+      ],
+    };
+    expect(serializeWidgetDataToCsv(data)).toBe(
+      'breakdown_label,label,value,total\n' +
+        'Austria,Forestry,1,1\n' +
+        'Belgium,Agriculture,2,2\n' +
+        'Belgium,Forestry,1,2\n',
+    );
+  });
+
+  it('escapes commas, quotes and newlines in string fields', () => {
+    const data: WidgetData = {
+      chart: [
+        { label: 'Hello, world', value: 1, total: 2 },
+        { label: 'She said "hi"', value: 1, total: 2 },
+      ],
+    };
+    expect(serializeWidgetDataToCsv(data)).toBe(
+      'label,value,total\n' +
+        '"Hello, world",1,2\n' +
+        '"She said ""hi""",1,2\n',
+    );
+  });
+
+  it('returns header only when chart/breakdown/map is empty', () => {
+    expect(serializeWidgetDataToCsv({ chart: [] })).toBe('label,value,total\n');
+    expect(serializeWidgetDataToCsv({ map: [] })).toBe('country,value\n');
+    expect(serializeWidgetDataToCsv({ breakdown: [] })).toBe(
+      'breakdown_label,label,value,total\n',
+    );
+  });
+
+  it('throws when the widget has no exportable data (navigation)', () => {
+    const data: WidgetData = { navigation: { href: '/somewhere' } };
+    expect(() => serializeWidgetDataToCsv(data)).toThrow(/cannot be exported/i);
+  });
+
+  it('throws when the widget data object is empty', () => {
+    expect(() => serializeWidgetDataToCsv({})).toThrow(/cannot be exported/i);
+  });
+});

--- a/api/src/modules/widgets/csv/widget-data.csv.ts
+++ b/api/src/modules/widgets/csv/widget-data.csv.ts
@@ -1,0 +1,75 @@
+import { stringify } from 'csv-stringify/sync';
+import { WidgetData } from '@shared/dto/widgets/base-widget-data.interface';
+
+export type WidgetDataField = 'counter' | 'chart' | 'map' | 'breakdown';
+
+export class NonExportableWidgetError extends Error {
+  constructor(reason: string) {
+    super(`Widget cannot be exported: ${reason}`);
+    this.name = 'NonExportableWidgetError';
+  }
+}
+
+export function serializeWidgetDataToCsv(
+  data: WidgetData,
+  preferredField?: WidgetDataField,
+): string {
+  const field = resolveField(data, preferredField);
+
+  switch (field) {
+    case 'counter':
+      return stringify([data.counter!], {
+        header: true,
+        columns: ['value', 'total'],
+      });
+
+    case 'chart':
+      return stringify(data.chart!, {
+        header: true,
+        columns: ['label', 'value', 'total'],
+      });
+
+    case 'map':
+      return stringify(data.map!, {
+        header: true,
+        columns: ['country', 'value'],
+      });
+
+    case 'breakdown': {
+      const rows = data.breakdown!.flatMap((group) =>
+        group.data.map((row) => ({
+          breakdown_label: group.label,
+          label: row.label,
+          value: row.value,
+          total: row.total,
+        })),
+      );
+      return stringify(rows, {
+        header: true,
+        columns: ['breakdown_label', 'label', 'value', 'total'],
+      });
+    }
+  }
+}
+
+function resolveField(
+  data: WidgetData,
+  preferredField: WidgetDataField | undefined,
+): WidgetDataField {
+  if (data.navigation) {
+    throw new NonExportableWidgetError(
+      'navigation widgets have no tabular data',
+    );
+  }
+
+  if (preferredField && data[preferredField] !== undefined) {
+    return preferredField;
+  }
+
+  if (data.counter) return 'counter';
+  if (data.chart) return 'chart';
+  if (data.map) return 'map';
+  if (data.breakdown) return 'breakdown';
+
+  throw new NonExportableWidgetError('no data available');
+}

--- a/api/src/modules/widgets/widgets.controller.ts
+++ b/api/src/modules/widgets/widgets.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, HttpStatus } from '@nestjs/common';
+import { Controller, HttpStatus, Res } from '@nestjs/common';
+import type { Response } from 'express';
 import { WidgetsService } from './widgets.service';
 import { TsRestHandler, tsRestHandler } from '@ts-rest/nest';
 import { widgetsContract as c } from '@shared/contracts/base-widgets.contract';
@@ -27,6 +28,24 @@ export class WidgetsController {
         query,
       );
       return { body: { data: widget }, status: HttpStatus.OK };
+    });
+  }
+
+  @Public()
+  @TsRestHandler(c.exportWidget)
+  public async exportWidget(
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<ControllerResponse> {
+    return tsRestHandler(c.exportWidget, async ({ params: { id }, query }) => {
+      const { csv, filename } = await this.widgetsService.exportWidgetCsv(
+        id,
+        query,
+      );
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${filename}"`,
+      );
+      return { body: csv, status: HttpStatus.OK };
     });
   }
 }

--- a/api/src/modules/widgets/widgets.service.ts
+++ b/api/src/modules/widgets/widgets.service.ts
@@ -1,6 +1,12 @@
 import { AppBaseService } from '@api/utils/app-base.service';
 import { AppInfoDTO } from '@api/utils/info.dto';
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { BaseWidget } from '@shared/dto/widgets/base-widget.entity';
 import { Repository, SelectQueryBuilder } from 'typeorm';
@@ -12,6 +18,16 @@ import {
   ISurveyAnswerRepository,
   SurveyAnswerRepository,
 } from '@api/infrastructure/survey-answer-repository.interface';
+import {
+  NonExportableWidgetError,
+  serializeWidgetDataToCsv,
+  WidgetDataField,
+} from '@api/modules/widgets/csv/widget-data.csv';
+import { buildCsvFilename } from '@api/modules/widgets/csv/filename';
+import {
+  WIDGET_VISUALIZATIONS,
+  WidgetVisualizationsType,
+} from '@shared/dto/widgets/widget-visualizations.constants';
 
 @Injectable()
 export class WidgetsService extends AppBaseService<
@@ -77,5 +93,59 @@ export class WidgetsService extends AppBaseService<
       });
 
     return baseWidgetWithData;
+  }
+
+  public async exportWidgetCsv(
+    id: string,
+    query: FetchSpecification & SearchWidgetDataParamsSchema,
+    now: Date = new Date(),
+  ): Promise<{ csv: string; filename: string }> {
+    const widget = await this.findWidgetWithDataById(id, query);
+    const preferredField = pickPreferredDataField(
+      query.breakdown,
+      widget.defaultVisualization,
+    );
+    try {
+      const csv = serializeWidgetDataToCsv(widget.data, preferredField);
+      const titleForFilename =
+        firstNonBlank(widget.title, widget.question) ?? widget.indicator;
+      const filename = buildCsvFilename(titleForFilename, now);
+      return { csv, filename };
+    } catch (error) {
+      if (error instanceof NonExportableWidgetError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+  }
+}
+
+function firstNonBlank(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  for (const value of values) {
+    if (value && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickPreferredDataField(
+  breakdown: string | undefined,
+  visualization: WidgetVisualizationsType | undefined,
+): WidgetDataField | undefined {
+  if (breakdown) return 'breakdown';
+  switch (visualization) {
+    case WIDGET_VISUALIZATIONS.SINGLE_VALUE:
+      return 'counter';
+    case WIDGET_VISUALIZATIONS.MAP:
+      return 'map';
+    case WIDGET_VISUALIZATIONS.HORIZONTAL_BAR_CHART:
+    case WIDGET_VISUALIZATIONS.PIE_CHART:
+    case WIDGET_VISUALIZATIONS.AREA_GRAPH:
+      return 'chart';
+    default:
+      return undefined;
   }
 }

--- a/api/test/e2e/projections/export-projection.spec.ts
+++ b/api/test/e2e/projections/export-projection.spec.ts
@@ -1,0 +1,197 @@
+import { TestManager } from 'api/test/utils/test-manager';
+import { projectionsContract as c } from '@shared/contracts/projections.contract';
+import { ConfigurationParams } from '@shared/dto/global/configuration-params';
+import { DataSourceManager } from '@api/infrastructure/data-source-manager';
+import { PROJECTION_VISUALIZATIONS } from '@shared/dto/projections/projection-visualizations.constants';
+import { parse } from 'csv-parse/sync';
+
+describe('Projections CSV export', () => {
+  let testManager: TestManager<unknown>;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager({ logger: false });
+    await testManager.dataSource.getRepository(ConfigurationParams).clear();
+    await testManager.getModule(DataSourceManager).loadInitialData();
+  });
+
+  afterAll(async () => {
+    await testManager.clearDatabase();
+    await testManager.close();
+  });
+
+  describe('GET /projections/custom-widget/export', () => {
+    it('returns 200 with text/csv and a dated attachment filename', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/csv');
+      expect(res.headers['content-disposition']).toMatch(
+        /^attachment; filename="custom-projection-\d{4}-\d{2}-\d{2}\.csv"$/,
+      );
+    });
+
+    it('serializes a simple (line chart) projection with unit,year,vertical,color columns', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+        });
+
+      expect(res.status).toBe(200);
+      const rows = parse(res.text, { columns: true });
+      expect(rows.length).toBeGreaterThan(0);
+      expect(Object.keys(rows[0]).sort()).toEqual(
+        ['unit', 'year', 'vertical', 'color'].sort(),
+      );
+    });
+
+    it('serializes a bubble projection with all dimensional columns', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.BUBBLE_CHART]: {
+              bubble: 'technology-type',
+              vertical: 'revenues',
+              horizontal: 'addressable-market',
+              size: 'penetration',
+              color: 'country',
+            },
+          },
+        });
+
+      expect(res.status).toBe(200);
+      const rows = parse(res.text, { columns: true });
+      expect(rows.length).toBeGreaterThan(0);
+      expect(Object.keys(rows[0]).sort()).toEqual(
+        [
+          'unit',
+          'year',
+          'bubble',
+          'color',
+          'vertical',
+          'horizontal',
+          'size',
+        ].sort(),
+      );
+    });
+
+    it('serializes a table projection with technology_type (snake_case) and other columns', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.TABLE]: {
+              vertical: 'market-potential',
+              color: 'country',
+            },
+          },
+        });
+
+      expect(res.status).toBe(200);
+      const rows = parse(res.text, { columns: true });
+      expect(rows.length).toBeGreaterThan(0);
+      expect(Object.keys(rows[0]).sort()).toEqual(
+        [
+          'unit',
+          'year',
+          'value',
+          'scenario',
+          'technology',
+          'technology_type',
+          'country',
+          'category',
+        ].sort(),
+      );
+    });
+
+    it('serializes a breakdown projection in long format', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'revenues',
+              color: 'country',
+            },
+          },
+          breakdown: 'technology',
+        });
+
+      expect(res.status).toBe(200);
+      const rows = parse(res.text, { columns: true });
+      expect(rows.length).toBeGreaterThan(0);
+      expect(Object.keys(rows[0]).sort()).toEqual(
+        ['unit', 'breakdown_label', 'label', 'value', 'total'].sort(),
+      );
+    });
+
+    it('returns 400 when the settings are invalid', async () => {
+      const res = await testManager
+        .request()
+        .get(c.exportCustomProjection.path)
+        .query({
+          settings: {
+            [PROJECTION_VISUALIZATIONS.LINE_CHART]: {
+              vertical: 'invalid_indicator',
+            },
+          },
+        });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /projections/widgets/:id/export', () => {
+    it('returns 404 for an unknown widget id', async () => {
+      const res = await testManager
+        .request()
+        .get('/projections/widgets/999999/export');
+      expect(res.status).toBe(404);
+    });
+
+    it('exports an existing projection widget as CSV with unit,year,value columns', async () => {
+      const listRes = await testManager
+        .request()
+        .get(c.getProjectionsWidgets.path);
+      expect(listRes.status).toBe(200);
+      const widgets = listRes.body.data as Array<{ id: number }>;
+      expect(widgets.length).toBeGreaterThan(0);
+      const widgetId = widgets[0].id;
+
+      const res = await testManager
+        .request()
+        .get(`/projections/widgets/${widgetId}/export`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/csv');
+      expect(res.headers['content-disposition']).toMatch(
+        /^attachment; filename=".+-\d{4}-\d{2}-\d{2}\.csv"$/,
+      );
+      const rows = parse(res.text, { columns: true });
+      expect(rows.length).toBeGreaterThan(0);
+      expect(Object.keys(rows[0]).sort()).toEqual(
+        ['unit', 'year', 'value'].sort(),
+      );
+    });
+  });
+});

--- a/api/test/e2e/widgets/export-widget.spec.ts
+++ b/api/test/e2e/widgets/export-widget.spec.ts
@@ -1,0 +1,151 @@
+import { TestManager } from 'api/test/utils/test-manager';
+import { DataSourceManager } from '@api/infrastructure/data-source-manager';
+import { BaseWidget } from '@shared/dto/widgets/base-widget.entity';
+import { WIDGET_VISUALIZATIONS } from '@shared/dto/widgets/widget-visualizations.constants';
+import { parse } from 'csv-parse/sync';
+
+const TEST_SURVEYS_DATA_PATH = `${__dirname}/../../data/surveys.json`;
+
+describe('Widgets CSV export', () => {
+  let testManager: TestManager<unknown>;
+  let dataSourceManager: DataSourceManager;
+  let mocks: ReturnType<TestManager<unknown>['mocks']>;
+
+  beforeAll(async () => {
+    testManager = await TestManager.createTestManager({ logger: false });
+    dataSourceManager = testManager.getModule(DataSourceManager);
+    mocks = testManager.mocks();
+    await testManager.clearDatabase();
+    await dataSourceManager.loadQuestionIndicatorMap();
+    await dataSourceManager.loadSurveyData(TEST_SURVEYS_DATA_PATH);
+  });
+
+  afterAll(async () => {
+    await testManager.close();
+  });
+
+  beforeEach(async () => {
+    await testManager
+      .getDataSource()
+      .getRepository(BaseWidget)
+      .createQueryBuilder()
+      .delete()
+      .execute();
+  });
+
+  describe('GET /widgets/:id/export', () => {
+    it('returns 200 with text/csv and a dated attachment filename derived from the widget title', async () => {
+      await mocks.createBaseWidget({
+        indicator: 'total-surveys',
+        question: 'Total Surveys',
+      });
+
+      const response = await testManager
+        .request()
+        .get('/widgets/total-surveys/export');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toContain('text/csv');
+      expect(response.headers['content-disposition']).toMatch(
+        /^attachment; filename="total-surveys-\d{4}-\d{2}-\d{2}\.csv"$/,
+      );
+    });
+
+    it('serializes a counter (single_value) widget as one data row', async () => {
+      await mocks.createBaseWidget({
+        indicator: 'total-surveys',
+        question: 'Total Surveys',
+      });
+
+      const response = await testManager
+        .request()
+        .get('/widgets/total-surveys/export');
+
+      const rows = parse(response.text, { columns: true });
+      expect(rows).toEqual([{ value: '5', total: '5' }]);
+    });
+
+    it('serializes a chart widget honoring filters', async () => {
+      await mocks.createBaseWidget({
+        indicator: 'type-of-stakeholder',
+        question: 'Type of Stakeholder',
+      });
+
+      const response = await testManager
+        .request()
+        .get(
+          '/widgets/type-of-stakeholder/export?filters[0][name]=sector&filters[0][operator]==&filters[0][values][0]=Agriculture',
+        );
+
+      expect(response.status).toBe(200);
+      const rows = parse(response.text, { columns: true });
+      expect(rows).toEqual([
+        { label: 'Farmer/agricultural producers', value: '1', total: '2' },
+        { label: 'Platform provider', value: '1', total: '2' },
+      ]);
+    });
+
+    it('serializes a breakdown widget in long format', async () => {
+      await mocks.createBaseWidget({
+        indicator: 'sector',
+        question: 'Sector',
+      });
+
+      const response = await testManager
+        .request()
+        .get('/widgets/sector/export?breakdown=location-country-region');
+
+      expect(response.status).toBe(200);
+      const rows = parse(response.text, { columns: true });
+      expect(rows).toEqual([
+        {
+          breakdown_label: 'Austria',
+          label: 'Forestry',
+          value: '1',
+          total: '1',
+        },
+        {
+          breakdown_label: 'Belgium',
+          label: 'Agriculture',
+          value: '2',
+          total: '2',
+        },
+        {
+          breakdown_label: 'Bulgaria',
+          label: 'Both',
+          value: '1',
+          total: '1',
+        },
+        {
+          breakdown_label: 'Netherlands',
+          label: 'Forestry',
+          value: '1',
+          total: '1',
+        },
+      ]);
+    });
+
+    it('returns 400 for a navigation widget (no tabular data)', async () => {
+      await mocks.createBaseWidget({
+        indicator: 'some-navigation',
+        question: 'Navigation',
+        visualisations: [WIDGET_VISUALIZATIONS.NAVIGATION],
+        defaultVisualization: WIDGET_VISUALIZATIONS.NAVIGATION,
+      });
+
+      const response = await testManager
+        .request()
+        .get('/widgets/some-navigation/export');
+
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 404 for an unknown widget indicator', async () => {
+      const response = await testManager
+        .request()
+        .get('/widgets/non-existent/export');
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       config:
         specifier: 4.4.1
         version: 4.4.1
+      csv-stringify:
+        specifier: 6.7.0
+        version: 6.7.0
       jsonapi-serializer:
         specifier: 3.6.9
         version: 3.6.9
@@ -3411,8 +3414,8 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/types@0.1.26':
-    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+  '@swc/types@0.1.25':
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
 
   '@t3-oss/env-core@0.10.1':
     resolution: {integrity: sha512-GcKZiCfWks5CTxhezn9k5zWX3sMDIYf6Kaxy2Gx9YEQftFcz8hDRN56hcbylyAO3t4jQnQ5ifLawINsNgCDpOg==}
@@ -4662,6 +4665,9 @@ packages:
 
   csv-parse@6.1.0:
     resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
+
+  csv-stringify@6.7.0:
+    resolution: {integrity: sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==}
 
   d3-array@2.12.1:
     resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
@@ -11215,7 +11221,7 @@ snapshots:
   '@swc/core@1.15.13':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.26
+      '@swc/types': 0.1.25
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.15.13
       '@swc/core-darwin-x64': 1.15.13
@@ -11236,7 +11242,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/types@0.1.26':
+  '@swc/types@0.1.25':
     dependencies:
       '@swc/counter': 0.1.3
     optional: true
@@ -12599,6 +12605,8 @@ snapshots:
   csstype@3.2.3: {}
 
   csv-parse@6.1.0: {}
+
+  csv-stringify@6.7.0: {}
 
   d3-array@2.12.1:
     dependencies:

--- a/shared/contracts/base-widgets.contract.ts
+++ b/shared/contracts/base-widgets.contract.ts
@@ -12,6 +12,12 @@ import { BaseWidgetWithData } from '@shared/dto/widgets/base-widget-data.interfa
 import { SearchWidgetDataParamsSchema } from '@shared/schemas/search-widget-data-params.schema';
 
 const contract = initContract();
+
+const CsvResponse = contract.otherResponse({
+  contentType: 'text/csv; charset=utf-8',
+  body: z.string(),
+});
+
 export const widgetsContract = contract.router({
   getWidgets: {
     method: 'GET',
@@ -42,5 +48,20 @@ export const widgetsContract = contract.router({
       500: contract.type<JSONAPIError>(),
     },
     summary: 'Get a widget by id',
+  },
+  exportWidget: {
+    method: 'GET',
+    path: '/widgets/:id/export',
+    pathParams: z.object({
+      id: z.coerce.string(),
+    }),
+    query: SearchWidgetDataParamsSchema,
+    responses: {
+      200: CsvResponse,
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+    summary: "Download a widget's data as a CSV file",
   },
 });

--- a/shared/contracts/projections.contract.ts
+++ b/shared/contracts/projections.contract.ts
@@ -8,8 +8,15 @@ import { CustomProjectionSettingsSchema } from '@shared/schemas/custom-projectio
 import { generateEntityQuerySchema } from '@shared/schemas/query-param.schema';
 import { SearchFiltersSchema } from '@shared/schemas/search-filters.schema';
 import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
 
 const contract = initContract();
+
+const CsvResponse = contract.otherResponse({
+  contentType: 'text/csv; charset=utf-8',
+  body: z.string(),
+});
+
 export const projectionsContract = contract.router({
   getProjectionsFilters: {
     method: 'GET',
@@ -53,5 +60,29 @@ export const projectionsContract = contract.router({
       400: contract.type<JSONAPIError>(),
       500: contract.type<JSONAPIError>(),
     },
+  },
+  exportProjectionWidget: {
+    method: 'GET',
+    path: '/projections/widgets/:id/export',
+    pathParams: z.object({ id: z.coerce.number() }),
+    query: SearchFiltersSchema,
+    responses: {
+      200: CsvResponse,
+      400: contract.type<JSONAPIError>(),
+      404: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+    summary: "Download a projection widget's data as a CSV file",
+  },
+  exportCustomProjection: {
+    method: 'GET',
+    path: '/projections/custom-widget/export',
+    query: SearchFiltersSchema.merge(CustomProjectionSettingsSchema),
+    responses: {
+      200: CsvResponse,
+      400: contract.type<JSONAPIError>(),
+      500: contract.type<JSONAPIError>(),
+    },
+    summary: "Download a custom projection's data as a CSV file",
   },
 });


### PR DESCRIPTION
## Summary

Users can now download any widget's data as a CSV file for offline analysis. Covers Survey and Projections, both Explore and Sandbox.

## New endpoints

All three are contract-first via `ts-rest` using `c.otherResponse({ contentType: 'text/csv; charset=utf-8' })`. They accept the same query params as their JSON data counterparts, so applied filters and breakdowns are reflected in the exported data.

| Endpoint | Covers |
|---|---|
| `GET /widgets/:id/export` | Survey Explore and Sandbox (filters + breakdown via query params) |
| `GET /projections/widgets/:id/export` | Projections Explore (single projection widget) |
| `GET /projections/custom-widget/export` | Projections Sandbox (custom projection with settings) |

All responses stream a CSV body with:
- `Content-Type: text/csv; charset=utf-8`
- `Content-Disposition: attachment; filename="<slug(widget title)>-<YYYY-MM-DD>.csv"` (UTC)

Navigation widgets return `400` (no tabular data to export). Unknown widgets return `404`.

## CSV shapes

Pure serializers live in `api/src/modules/widgets/csv/` and are exhaustively unit-tested with 20 fixtures. One data row per widget type:

**Survey widgets:**
- `counter` (`single_value`): `value,total`
- `chart` (bar / pie / area): `label,value,total`
- `map`: `country,value`
- `breakdown`: long format `breakdown_label,label,value,total`

**Projection widgets** (auto-detected, unit dimension unrolled as a column):
- simple line/bar: `unit,year,vertical,color`
- bubble: `unit,year,bubble,color,vertical,horizontal,size`
- table: `unit,year,value,scenario,technology,technology_type,country,category`
- breakdown: `unit,breakdown_label,label,value,total`
- base projection widget: `unit,year,value`

The serializer respects `widget.defaultVisualization` and the optional `breakdown` query param to pick the right field when multiple are populated (e.g., widgets that expose both `chart` and `map`).

## Out of scope

- Frontend download button: will be a separate PR (the ticket is labeled BE). The WCAG 2.1 AA accessibility acceptance criterion applies to the FE button; the backend satisfies its part by returning `Content-Disposition: attachment` so the browser handles the download natively.
- Localized CSV delimiter (`;` for Excel ES): not requested; defaults to `,`. Easy to add later as an optional `?delimiter=` query param if needed.