### PR TITLE
feat(client): add CSV download to widget menus (SIRH-385)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ Thumbs.db
 
 # Data files located in data-processing
 data-processing/data/**
+
+# Claude
+.claude/
+AGENTS.md
+CLAUDE.md

--- a/client/src/containers/explore/projections/index.tsx
+++ b/client/src/containers/explore/projections/index.tsx
@@ -71,6 +71,7 @@ export default function Explore() {
         {data?.map((d) => (
           <Widget
             key={d.id}
+            id={d.id}
             indicator={d.title}
             description={d.description}
             data={d.data}

--- a/client/src/containers/sandbox/projections-sandbox/index.tsx
+++ b/client/src/containers/sandbox/projections-sandbox/index.tsx
@@ -7,6 +7,9 @@ import {
   SimpleProjection,
 } from "@shared/dto/projections/custom-projection.type";
 import { ProjectionVisualizationsType } from "@shared/dto/projections/projection-visualizations.constants";
+import qs from "qs";
+
+import { env } from "@/env";
 
 import { client } from "@/lib/queryClient";
 import { queryKeys } from "@/lib/queryKeys";
@@ -137,12 +140,18 @@ const Sandbox: FC = () => {
       </Card>
     );
 
+  const downloadUrl = `${env.NEXT_PUBLIC_API_URL}/projections/custom-widget/export?${qs.stringify(
+    { filters, settings, othersAggregation },
+    { encode: false },
+  )}`;
+
   return (
     <SandboxWidget
       className="justify-end"
       indicator={indicator}
       visualization={visualization}
       data={data}
+      downloadUrl={downloadUrl}
     />
   );
 };

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -5,8 +5,11 @@ import { useEffect, useMemo, useState } from "react";
 import { ProjectionVisualizationsType } from "@shared/dto/projections/projection-visualizations.constants";
 import { ProjectionWidgetData } from "@shared/dto/projections/projection-widget.entity";
 import { useAtom } from "jotai";
+import qs from "qs";
 
+import { env } from "@/env";
 import { cn } from "@/lib/utils";
+import useFilters from "@/hooks/use-filters";
 
 import { focusedWidgetAtom } from "@/containers/explore/store";
 import NoData from "@/containers/no-data";
@@ -23,6 +26,7 @@ import WidgetHeader from "@/containers/widget/widget-header";
 import { Card } from "@/components/ui/card";
 
 export interface WidgetProps {
+  id: number;
   indicator: string;
   visualization: ProjectionVisualizationsType;
   data?: ProjectionWidgetData;
@@ -42,6 +46,7 @@ export interface WidgetProps {
 }
 
 export default function Widget({
+  id,
   indicator,
   visualization,
   visualisations,
@@ -60,6 +65,11 @@ export default function Widget({
     useState<ProjectionVisualizationsType>(visualization);
   const [showOverlay, setShowOverlay] = useAtom(showOverlayAtom);
   const [focusedWidget, setFocusedWidget] = useAtom(focusedWidgetAtom);
+  const { filters } = useFilters();
+  const downloadUrl = `${env.NEXT_PUBLIC_API_URL}/projections/widgets/${id}/export?${qs.stringify(
+    { filters },
+    { encode: false },
+  )}`;
   const highlightWidget = showOverlay && indicator === focusedWidget;
   const menuComponent = (
     <WidgetMenu
@@ -71,6 +81,7 @@ export default function Widget({
       setFocusedWidget={setFocusedWidget}
       setSelectedVisualization={setSelectedVisualization}
       indicator={indicator}
+      downloadUrl={downloadUrl}
       className={config?.menu?.className}
     />
   );

--- a/client/src/containers/widget/projections/menu/index.tsx
+++ b/client/src/containers/widget/projections/menu/index.tsx
@@ -28,6 +28,7 @@ interface WidgetMenuProps {
   setShowOverlay: (open: boolean) => void;
   setFocusedWidget: (indicator: string | null) => void;
   indicator: string;
+  downloadUrl?: string;
 }
 
 const WidgetMenu: FC<WidgetMenuProps> = ({
@@ -37,12 +38,13 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
   info,
   className,
   indicator,
+  downloadUrl,
   setSelectedVisualization,
   setShowOverlay,
   setFocusedWidget,
 }) => {
   const setInfo = useSetAtom(infoAtom);
-  if (!visualisations && !showCustomizeWidgetButton) return null;
+  if (!visualisations && !showCustomizeWidgetButton && !downloadUrl) return null;
 
   return (
     <>
@@ -76,6 +78,13 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
             >
               Customize chart
             </Link>
+          </Button>
+        )}
+        {downloadUrl && (
+          <Button variant="clean" className={btnClassName} asChild>
+            <a href={downloadUrl} download>
+              Download as CSV
+            </a>
           </Button>
         )}
         {visualisations && (

--- a/client/src/containers/widget/projections/sandbox/index.tsx
+++ b/client/src/containers/widget/projections/sandbox/index.tsx
@@ -12,6 +12,7 @@ import { ProjectionVisualizationsType } from "@shared/dto/projections/projection
 import { cn } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
+import MenuButton from "@/containers/menu-button";
 import BubbleChart from "@/containers/widget/bubble-chart";
 import WidgetLegend from "@/containers/widget/legend";
 import LineChart from "@/containers/widget/line-chart";
@@ -23,6 +24,7 @@ import {
 import VerticalBarChart from "@/containers/widget/vertical-bar-chart";
 import WidgetHeader from "@/containers/widget/widget-header";
 
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import TableView from "@/containers/widget/table";
 
@@ -31,13 +33,18 @@ export interface SandboxWidgetProps {
   visualization: ProjectionVisualizationsType;
   data: CustomProjection;
   className?: string;
+  downloadUrl?: string;
 }
+
+const btnClassName =
+  "block w-full rounded-none px-4 py-3.5 text-left text-xs font-medium transition-colors hover:bg-muted";
 
 export default function SandboxWidget({
   indicator,
   visualization,
   data,
   className,
+  downloadUrl,
 }: SandboxWidgetProps) {
   const units = useMemo(() => (data ? Object.keys(data) : []), [data]);
   const [selectedUnit, setSelectedUnit] = useState(
@@ -59,6 +66,15 @@ export default function SandboxWidget({
       className="p-0"
     />
   );
+  const menuComponent = downloadUrl ? (
+    <MenuButton>
+      <Button variant="clean" className={btnClassName} asChild>
+        <a href={downloadUrl} download>
+          Download as CSV
+        </a>
+      </Button>
+    </MenuButton>
+  ) : undefined;
 
   useEffect(() => {
     setSelectedUnit(getDefaultProjectionUnit(data, indicator));
@@ -82,6 +98,7 @@ export default function SandboxWidget({
             title={indicator}
             className="pb-0"
             select={selectComponent}
+            menu={menuComponent}
           />
           <WidgetLegend colors={simpleChartProps.colors} className="m-6" />
           <VerticalBarChart unit={selectedUnit} {...simpleChartProps} />
@@ -94,6 +111,7 @@ export default function SandboxWidget({
             title={indicator}
             className="pb-0"
             select={selectComponent}
+            menu={menuComponent}
           />
           <WidgetLegend colors={simpleChartProps.colors} className="m-6" />
           <LineChart
@@ -111,6 +129,7 @@ export default function SandboxWidget({
               title={indicator}
               className="p-0"
               select={selectComponent}
+              menu={menuComponent}
             />
             <BubbleChart data={data as BubbleProjection} unit={selectedUnit} />
           </Card>
@@ -124,6 +143,7 @@ export default function SandboxWidget({
             title={indicator}
             className="pb-0"
             select={selectComponent}
+            menu={menuComponent}
           />
           <TableView
             indicator={indicator}

--- a/client/src/containers/widget/survey-analysis/index.tsx
+++ b/client/src/containers/widget/survey-analysis/index.tsx
@@ -7,6 +7,10 @@ import {
   WidgetVisualizationsType,
 } from "@shared/dto/widgets/widget-visualizations.constants";
 import { useAtom } from "jotai";
+import qs from "qs";
+
+import { env } from "@/env";
+import useFilters from "@/hooks/use-filters";
 
 import { removeNaLabels } from "@/lib/normalize-widget-data";
 import { cn, isEmptyWidget } from "@/lib/utils";
@@ -76,6 +80,11 @@ export default function Widget({
   const [showOverlay, setShowOverlay] = useAtom(showOverlayAtom);
   const [focusedWidget, setFocusedWidget] = useAtom(focusedWidgetAtom);
   const highlightWidget = showOverlay && indicator === focusedWidget;
+  const { filters } = useFilters();
+  const downloadUrl = `${env.NEXT_PUBLIC_API_URL}/widgets/${indicator}/export?${qs.stringify(
+    { filters, ...(breakdown ? { breakdown } : {}) },
+    { encode: false },
+  )}`;
   const menuComponent = menu || (
     <WidgetMenu
       visualisations={visualisations}
@@ -86,6 +95,7 @@ export default function Widget({
       setFocusedWidget={setFocusedWidget}
       setSelectedVisualization={setSelectedVisualization}
       indicator={indicator}
+      downloadUrl={downloadUrl}
       className={cn("p-0", config?.menu?.className)}
     />
   );
@@ -117,7 +127,7 @@ export default function Widget({
           className,
         )}
       >
-        <WidgetHeader title={title} question={question} menu={menu} />
+        <WidgetHeader title={title} question={question} menu={menuComponent} />
         <Breakdown data={data.percentages.breakdown} />
       </Card>
     );

--- a/client/src/containers/widget/survey-analysis/menu/index.tsx
+++ b/client/src/containers/widget/survey-analysis/menu/index.tsx
@@ -40,6 +40,7 @@ interface WidgetMenuProps {
   setShowOverlay: (open: boolean) => void;
   setFocusedWidget: (indicator: string | null) => void;
   indicator: string;
+  downloadUrl?: string;
 }
 
 const WidgetMenu: FC<WidgetMenuProps> = ({
@@ -49,12 +50,13 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
   info,
   className,
   indicator,
+  downloadUrl,
   setSelectedVisualization,
   setShowOverlay,
   setFocusedWidget,
 }) => {
   const setInfo = useSetAtom(infoAtom);
-  if (!visualisations && !showCustomizeWidgetButton) return null;
+  if (!visualisations && !showCustomizeWidgetButton && !downloadUrl) return null;
 
   return (
     <>
@@ -88,6 +90,13 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
             >
               Customize chart
             </Link>
+          </Button>
+        )}
+        {downloadUrl && (
+          <Button variant="clean" className={btnClassName} asChild>
+            <a href={downloadUrl} download>
+              Download as CSV
+            </a>
           </Button>
         )}
         {visualisations && (

--- a/client/tests/widget/widget.test.tsx
+++ b/client/tests/widget/widget.test.tsx
@@ -64,6 +64,14 @@ vi.mock("@/containers/widget/breakdown", () => ({
   default: () => <div data-testid="breakdown">Breakdown Chart</div>,
 }));
 
+vi.mock("@/hooks/use-filters", () => ({
+  default: () => ({ filters: [] }),
+}));
+
+vi.mock("@/env", () => ({
+  env: { NEXT_PUBLIC_API_URL: "http://localhost:4000" },
+}));
+
 describe("Widget", () => {
   const mockChartData = { chart: [{ label: "Test", value: 100, total: 100 }] };
   const mockProps: WidgetProps = {
@@ -100,10 +108,10 @@ describe("Widget", () => {
     });
   });
 
-  it("Hides the menu if no menuItems or visualisations are passed", () => {
+  it("Always shows the menu (download is always available)", () => {
     render(<Widget {...mockProps} />);
 
-    expect(screen.queryByTestId(menuButtonTestId)).not.toBeInTheDocument();
+    expect(screen.getByTestId(menuButtonTestId)).toBeInTheDocument();
   });
 
   it("renders the customize chart button with the correct href value", () => {
@@ -112,7 +120,7 @@ describe("Widget", () => {
     const menuButton = screen.getByTestId(menuButtonTestId);
     fireEvent.click(menuButton);
 
-    expect(screen.getByRole("link")).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Customize chart" })).toHaveAttribute(
       "href",
       getRouteHref("surveyAnalysis", "sandbox") +
         `?visualization=${mockProps.visualization}&indicator=${mockProps.indicator}`,


### PR DESCRIPTION
## Summary

- Adds a **"Download as CSV"** item to the ellipsis menu on all survey and projection widgets (explore + sandbox)
- Wires up three existing backend export endpoints already on \`dev\`: \`GET /widgets/:id/export\`, \`GET /projections/widgets/:id/export\`, \`GET /projections/custom-widget/export\`
- Uses a plain \`<a href download>\` anchor — the browser handles the file download natively, no client-side CSV generation needed
- Filters, breakdowns, and custom projection settings are serialized into the URL via \`qs.stringify\` (same format the API already expects)
- Ignores Claude config files (\`.claude/\`, \`AGENTS.md\`, \`CLAUDE.md\`) in \`.gitignore\`

## Test Plan

- [ ] Open \`/survey-analysis\` → ellipsis menu on any widget → "Download as CSV" → file downloads with widget data
- [ ] Apply a filter → re-download → CSV reflects the filter
- [ ] Repeat on \`/survey-analysis/sandbox\`
- [ ] Open \`/projections\` → same flow for explore widgets
- [ ] Open \`/projections\` sandbox → configure a visualization → "Download as CSV" → file downloads
- [ ] Keyboard: Tab to ellipsis → Enter → Tab to "Download as CSV" → Enter → file downloads
- [ ] \`cd client && pnpm test\` — 123 tests passing

## Related

Closes [SIRH-385](https://vizzuality.atlassian.net/browse/SIRH-385)

[SIRH-385]: https://vizzuality.atlassian.net/browse/SIRH-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ