### PR TITLE
fix(widgets): always render Others series with chart-12

### DIFF
--- a/client/src/containers/widget/breakdown/index.tsx
+++ b/client/src/containers/widget/breakdown/index.tsx
@@ -4,7 +4,7 @@ import React, { FC } from "react";
 import { WidgetBreakdownData } from "@shared/dto/widgets/base-widget-data.interface";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
-import { CSS_CHART_COLORS, TW_CHART_COLORS } from "@/lib/constants";
+import { getCssChartColor, getTwChartColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
@@ -38,8 +38,8 @@ const Breakdown: FC<BreakdownProps> = ({ data }) => {
   const labelColors = labels.reduce(
     (acc, label, index) => {
       acc[label] = {
-        css: CSS_CHART_COLORS[index],
-        tailwind: TW_CHART_COLORS[index],
+        css: getCssChartColor(label, index),
+        tailwind: getTwChartColor(label, index),
       };
       return acc;
     },

--- a/client/src/containers/widget/bubble-chart/index.tsx
+++ b/client/src/containers/widget/bubble-chart/index.tsx
@@ -11,7 +11,7 @@ import {
   Cell,
 } from "recharts";
 
-import { CSS_CHART_COLORS } from "@/lib/constants";
+import { getCssChartColor } from "@/lib/constants";
 import { cn, formatAndRoundUp } from "@/lib/utils";
 
 import useSettings from "@/hooks/use-settings";
@@ -135,11 +135,10 @@ const BubbleChart: FC<BubbleChartProps> = ({ data, unit }) => {
             {currentDataSet.map((d, index) => (
               <Cell
                 key={index}
-                fill={
-                  CSS_CHART_COLORS[
-                    colors.findIndex((color) => d.color === color)
-                  ]
-                }
+                fill={getCssChartColor(
+                  d.color,
+                  colors.findIndex((color) => d.color === color),
+                )}
               />
             ))}
           </Scatter>

--- a/client/src/containers/widget/legend/index.tsx
+++ b/client/src/containers/widget/legend/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 
-import { TW_CHART_COLORS } from "@/lib/constants";
+import { getTwChartColor } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 const WidgetLegend: FC<{
@@ -15,7 +15,10 @@ const WidgetLegend: FC<{
           className="flex items-center gap-x-1 text-xs"
         >
           <span
-            className={cn("block h-3 w-3 rounded-full", TW_CHART_COLORS[index])}
+            className={cn(
+              "block h-3 w-3 rounded-full",
+              getTwChartColor(color, index),
+            )}
           ></span>
           <span>{color}</span>
         </p>

--- a/client/src/containers/widget/line-chart/index.tsx
+++ b/client/src/containers/widget/line-chart/index.tsx
@@ -3,6 +3,7 @@ import { FC, useMemo } from "react";
 import { Line, LineChart as ReLinChart, XAxis, YAxis } from "recharts";
 import { DataKey } from "recharts/types/util/types";
 
+import { getCssChartColor } from "@/lib/constants";
 import { cn, formatAndRoundUp } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
@@ -78,7 +79,7 @@ const LineChart: FC<LineChartProps> = ({
             dataKey={c}
             type="linear"
             strokeWidth={10}
-            stroke={`hsl(var(--chart-${i + 1}))`}
+            stroke={getCssChartColor(c, i)}
             dot={false}
           />
         ))}

--- a/client/src/containers/widget/pie-chart/index.tsx
+++ b/client/src/containers/widget/pie-chart/index.tsx
@@ -4,7 +4,11 @@ import { FC, useMemo } from "react";
 import { WidgetChartData } from "@shared/dto/widgets/base-widget-data.interface";
 import { Pie, PieChart as RePieChart } from "recharts";
 
-import { MAX_PIE_CHART_LABELS_COUNT, TW_CHART_COLORS } from "@/lib/constants";
+import {
+  getCssChartColor,
+  getTwChartColor,
+  MAX_PIE_CHART_LABELS_COUNT,
+} from "@/lib/constants";
 import { cn, formatNumber } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
@@ -53,8 +57,7 @@ const PieChart: FC<PieChartProps> = ({
   return (
     <div
       className={cn({
-        "flex flex-1 flex-wrap items-center justify-center gap-4 gap-x-8 pl-6":
-          true,
+        "flex flex-1 flex-wrap items-center justify-center gap-4 gap-x-8 pl-6": true,
         "min-h-0 flex-col justify-between": legendPosition === "bottom",
       })}
     >
@@ -63,7 +66,7 @@ const PieChart: FC<PieChartProps> = ({
           <Pie
             data={normalizedData.map((d, i) => ({
               ...d,
-              fill: `hsl(var(--chart-${i + 1}))`,
+              fill: getCssChartColor(d.label, i),
             }))}
             dataKey="value"
             nameKey="label"
@@ -90,7 +93,10 @@ const PieChart: FC<PieChartProps> = ({
           >
             <span className="flex items-center gap-x-1">
               <span
-                className={cn("block h-3 w-3 rounded-full", TW_CHART_COLORS[i])}
+                className={cn(
+                  "block h-3 w-3 rounded-full",
+                  getTwChartColor(c.label, i),
+                )}
               ></span>
               <span className="font-black">{formatNumber(c.value)}%</span>
             </span>

--- a/client/src/containers/widget/tooltip/projections/index.tsx
+++ b/client/src/containers/widget/tooltip/projections/index.tsx
@@ -4,7 +4,7 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
 
-import { TW_CHART_COLORS } from "@/lib/constants";
+import { getTwChartColor } from "@/lib/constants";
 import { cn, formatNumber } from "@/lib/utils";
 
 const ProjectionsTooltip = ({
@@ -29,7 +29,10 @@ const ProjectionsTooltip = ({
         >
           <span className="flex flex-1 items-center justify-end gap-x-1">
             <span
-              className={cn("block h-3 w-3 rounded-full", TW_CHART_COLORS[i])}
+              className={cn(
+                "block h-3 w-3 rounded-full",
+                getTwChartColor(p.name, i),
+              )}
             ></span>
             <span>{p.name}</span>
           </span>

--- a/client/src/containers/widget/vertical-bar-chart/index.tsx
+++ b/client/src/containers/widget/vertical-bar-chart/index.tsx
@@ -3,6 +3,7 @@ import { FC, useState } from "react";
 
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
+import { getCssChartColor } from "@/lib/constants";
 import { cn, formatAndRoundUp } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
@@ -120,7 +121,7 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({
               return (
                 <Cell
                   key={`cell-${entry.year}-${index}`}
-                  fill={`hsl(var(--chart-${i + 1}))`}
+                  fill={getCssChartColor(c, i)}
                   // @ts-expect-error - Recharts Cell radius prop accepts [number, number, number, number] for corner radius
                   // but its type definition only allows string | number | undefined
                   radius={getRadius(index, data.length)}

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -30,6 +30,26 @@ export const CSS_CHART_COLORS = [
 
 export const MAX_PIE_CHART_LABELS_COUNT = CSS_CHART_COLORS.length - 1;
 
+export const OTHERS_LABEL = "Others";
+export const OTHERS_TW_COLOR = "bg-chart-12";
+export const OTHERS_CSS_COLOR = "hsl(var(--chart-12))";
+
+export function getTwChartColor(
+  identifier: string | number | undefined,
+  index: number,
+): string {
+  return identifier === OTHERS_LABEL ? OTHERS_TW_COLOR : TW_CHART_COLORS[index];
+}
+
+export function getCssChartColor(
+  identifier: string | number | undefined,
+  index: number,
+): string {
+  return identifier === OTHERS_LABEL
+    ? OTHERS_CSS_COLOR
+    : CSS_CHART_COLORS[index];
+}
+
 export const ADD_FILTER_MODE = {
   MERGE: 0,
   REPLACE: 1,


### PR DESCRIPTION
## fix(widgets): always render "Others" series with chart-12

### Overview
Keeps the "Others" bucket visually consistent across every widget surface. Previously the legend forced `bg-chart-12` for "Others" while the underlying chart geometry picked a color by array index, producing mismatched swatches and shapes.

### Changes
- New `OTHERS_LABEL` / `OTHERS_TW_COLOR` / `OTHERS_CSS_COLOR` constants plus `getTwChartColor` and `getCssChartColor` helpers in `client/src/lib/constants.ts` that short-circuit to chart-12 when the series identifier is `"Others"`.
- Pie, line, vertical bar, bubble and breakdown charts, the shared `WidgetLegend`, and the projections tooltip now resolve their colors through these helpers, so legend swatches, chart shapes and tooltip indicators always agree.
- No changes to color ordering, `MAX_PIE_CHART_LABELS_COUNT`, or existing tests.

### Breaking Changes
None.

### Technical Details
- Scope: client only; 8 files changed, +53 / -20.
- Related issue: N/A.