### PR TITLE
fix(projections): show decimals on y-axis and tooltip

### DIFF
--- a/client/src/containers/widget/line-chart/index.tsx
+++ b/client/src/containers/widget/line-chart/index.tsx
@@ -4,7 +4,7 @@ import { Line, LineChart as ReLinChart, XAxis, YAxis } from "recharts";
 import { DataKey } from "recharts/types/util/types";
 
 import { getCssChartColor } from "@/lib/constants";
-import { cn, formatAndRoundUp } from "@/lib/utils";
+import { cn, formatProjectionValue } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
 import { CHART_CONTAINER_CLASS_NAME } from "@/containers/widget/constants";
@@ -119,7 +119,7 @@ const LineChart: FC<LineChartProps> = ({
           tickLine={false}
           tick={({ x, y, payload }) => (
             <text x={x + 30} y={y} textAnchor="end" style={{ fontSize: 12 }}>
-              {formatAndRoundUp(payload.value)}
+              {formatProjectionValue(payload.value)}
             </text>
           )}
         />

--- a/client/src/containers/widget/tooltip/projections/index.tsx
+++ b/client/src/containers/widget/tooltip/projections/index.tsx
@@ -38,7 +38,7 @@ const ProjectionsTooltip = ({
           </span>
           <span className="flex flex-1 justify-start gap-1 font-bold">
             {formatNumber(Number(p.value), {
-              maximumFractionDigits: 0,
+              maximumFractionDigits: 2,
             })}
             <span className="text-muted-foreground">{unit}</span>
           </span>

--- a/client/src/containers/widget/vertical-bar-chart/index.tsx
+++ b/client/src/containers/widget/vertical-bar-chart/index.tsx
@@ -4,7 +4,7 @@ import { FC, useState } from "react";
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { getCssChartColor } from "@/lib/constants";
-import { cn, formatAndRoundUp } from "@/lib/utils";
+import { cn, formatProjectionValue } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
 import {
@@ -171,7 +171,7 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({
           style={{ transform: "translate(30px, -10px)" }}
           tick={({ x, y, payload }) => (
             <text x={x + 30} y={y} textAnchor="end" style={{ fontSize: 12 }}>
-              {formatAndRoundUp(payload.value)}
+              {formatProjectionValue(payload.value)}
             </text>
           )}
         />

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -105,6 +105,24 @@ export function formatNumber(
   }).format(value);
 }
 
+export function formatProjectionValue(value: number) {
+  const absValue = Math.abs(value);
+
+  if (absValue >= 1000) {
+    return formatNumber(value, {
+      notation: "compact",
+      compactDisplay: "short",
+      maximumFractionDigits: 1,
+    });
+  }
+
+  if (absValue >= 0) {
+    return formatNumber(value, { maximumFractionDigits: 2 });
+  }
+
+  return formatNumber(value, { maximumFractionDigits: 4 });
+}
+
 export function formatAndRoundUp(value: number) {
   if (value <= 0) return String(value);
 


### PR DESCRIPTION
## Summary

- Adds `formatProjectionValue()` utility that shows compact notation for values ≥1000 and up to 2 decimal places for smaller values
- Replaces `formatAndRoundUp` in line chart and vertical bar chart y-axis ticks (projections only)
- Updates projections tooltip to show up to 2 decimal places

Closes SIRH-395

## Test plan

- [ ] Navigate to Projections page, switch to line chart — y-axis shows decimals when values differ at sub-unit level
- [ ] Switch to bar chart — same behavior
- [ ] Hover a data point — tooltip shows up to 2 decimal places
- [ ] Large values (≥1000) still render compact (e.g. "1.2K")
- [ ] Survey analysis widgets (bubble chart etc.) unaffected