### PR TITLE
fix(projections): deduplicate y-axis tick labels

### DIFF
--- a/client/src/containers/widget/line-chart/index.tsx
+++ b/client/src/containers/widget/line-chart/index.tsx
@@ -4,7 +4,7 @@ import { Line, LineChart as ReLinChart, XAxis, YAxis } from "recharts";
 import { DataKey } from "recharts/types/util/types";
 
 import { getCssChartColor } from "@/lib/constants";
-import { cn, formatProjectionValue } from "@/lib/utils";
+import { cn, formatProjectionValue, getYAxisTicks } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
 import { CHART_CONTAINER_CLASS_NAME } from "@/containers/widget/constants";
@@ -115,6 +115,7 @@ const LineChart: FC<LineChartProps> = ({
           type="number"
           orientation="right"
           domain={yDomain}
+          ticks={getYAxisTicks(yDomain)}
           axisLine={false}
           tickLine={false}
           tick={({ x, y, payload }) => (

--- a/client/src/containers/widget/vertical-bar-chart/index.tsx
+++ b/client/src/containers/widget/vertical-bar-chart/index.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { FC, useState } from "react";
+import { FC, useMemo, useState } from "react";
 
 import { Bar, BarChart, Cell, XAxis, YAxis } from "recharts";
 
 import { getCssChartColor } from "@/lib/constants";
-import { cn, formatProjectionValue } from "@/lib/utils";
+import { cn, formatProjectionValue, getYAxisTicks } from "@/lib/utils";
 
 import NoData from "@/containers/no-data";
 import {
@@ -47,6 +47,16 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({
   enableHoverStyles,
 }) => {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  const yDomain = useMemo((): [number, number] => {
+    const keys = colors ? colors.map(String) : ["value"];
+    const values = data.flatMap((d) => keys.map((k) => d[k]).filter((v) => v != null));
+    if (values.length === 0) return [0, 1];
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const padding = (max - min) * 0.05 || 1;
+    return [min - padding, max + padding];
+  }, [data, colors]);
 
   if (!data || data.length === 0) {
     console.error(
@@ -166,6 +176,8 @@ const VerticalBarChart: FC<VerticalBarChartProps> = ({
         <YAxis
           type="number"
           orientation="right"
+          domain={yDomain}
+          ticks={getYAxisTicks(yDomain)}
           axisLine={false}
           tickLine={false}
           style={{ transform: "translate(30px, -10px)" }}

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -123,6 +123,19 @@ export function formatProjectionValue(value: number) {
   return formatNumber(value, { maximumFractionDigits: 4 });
 }
 
+export function getYAxisTicks(domain: [number, number], tickCount = 5): number[] {
+  const [min, max] = domain;
+  const step = (max - min) / (tickCount - 1);
+  const candidates = Array.from({ length: tickCount }, (_, i) => min + i * step);
+  const seen = new Set<string>();
+  return candidates.filter((v) => {
+    const label = formatProjectionValue(v);
+    if (seen.has(label)) return false;
+    seen.add(label);
+    return true;
+  });
+}
+
 export function formatAndRoundUp(value: number) {
   if (value <= 0) return String(value);
 


### PR DESCRIPTION
## Summary

- Adds `getYAxisTicks()` utility that generates evenly-spaced tick candidates and removes any that produce a duplicate formatted label (e.g. two ticks both rendering as "6.3B")
- `LineChart` and `VerticalBarChart` now pass explicit `ticks` and `domain` to `YAxis` instead of relying on Recharts auto-generation

## Test plan

- [ ] Open Projections with a scenario that has a tight value range — confirm no duplicate y-axis labels
- [ ] Open Projections with a wide value range — confirm y-axis still shows expected tick count
- [ ] Verify both line chart and bar chart views

Closes SIRH-395