### PR TITLE
fix(widgets): restore download button in survey analysis sandbox

### DIFF
--- a/client/src/containers/sandbox/index.tsx
+++ b/client/src/containers/sandbox/index.tsx
@@ -48,7 +48,7 @@ const Sandbox: FC = () => {
         question={widget.question}
         visualization={visualization || widget.defaultVisualization}
         data={widget.data}
-        menu={
+        extraHeaderActions={
           <CreateWidgetMenu
             indicator={indicator}
             visualization={visualization}

--- a/client/src/containers/sandbox/user-sandbox/index.tsx
+++ b/client/src/containers/sandbox/user-sandbox/index.tsx
@@ -107,7 +107,7 @@ const Sandbox: FC<SandboxProps> = ({ customWidgetId }) => {
           question={widget.question}
           visualization={visualization || widget.defaultVisualization}
           data={widget.data}
-          menu={
+          extraHeaderActions={
             <UpdateWidgetMenu
               widgetId={customWidgetId}
               indicator={indicator}

--- a/client/src/containers/widget/survey-analysis/index.tsx
+++ b/client/src/containers/widget/survey-analysis/index.tsx
@@ -45,6 +45,8 @@ export interface WidgetProps {
   question?: string;
   questionTitle?: string;
   menu?: React.ReactNode;
+  /** Shown next to the default menu (e.g. save widget); keeps CSV and visualization actions */
+  extraHeaderActions?: React.ReactNode;
   className?: string;
   showCustomizeWidgetButton?: boolean;
   config?: {
@@ -71,6 +73,7 @@ export default function Widget({
   question,
   questionTitle,
   menu,
+  extraHeaderActions,
   className,
   showCustomizeWidgetButton,
   config,
@@ -85,7 +88,7 @@ export default function Widget({
     { filters, ...(breakdown ? { breakdown } : {}) },
     { encode: false },
   )}`;
-  const menuComponent = menu || (
+  const defaultMenu = (
     <WidgetMenu
       visualisations={visualisations}
       info={description ? { title: indicator, description } : undefined}
@@ -99,6 +102,16 @@ export default function Widget({
       className={cn("p-0", config?.menu?.className)}
     />
   );
+  const menuComponent =
+    menu ??
+    (extraHeaderActions ? (
+      <div className="flex items-center gap-2">
+        {defaultMenu}
+        {extraHeaderActions}
+      </div>
+    ) : (
+      defaultMenu
+    ));
 
   useEffect(() => {
     setSelectedVisualization(visualization);


### PR DESCRIPTION
## Summary
- Sandbox components passed their save/create menu via the `menu` prop, which fully replaced the default `WidgetMenu` (containing CSV download and visualization switcher)
- Introduced `extraHeaderActions` prop on the survey analysis `Widget` component so sandbox actions render **alongside** the default menu, not instead of it
- Both `sandbox/index.tsx` and `user-sandbox/index.tsx` now use `extraHeaderActions`

Ref: [SIRH-385](https://vizzuality.atlassian.net/browse/SIRH-385)

## Test plan
- [ ] Open sandbox view → verify CSV download button appears alongside save widget button
- [ ] Open user sandbox (saved widget) → verify CSV download button appears alongside update widget button
- [ ] Open explore view → verify default menu unchanged (no regression)

[SIRH-385]: https://vizzuality.atlassian.net/browse/SIRH-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ