### PR TITLE
fix(deps): address 2 dependency vulnerabilities

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -38,7 +38,7 @@
     "@nestjs/terminus": "11.1.1",
     "@nestjs/typeorm": "11.0.0",
     "@ts-rest/nest": "3.52.1",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "bcrypt": "catalog:",
     "class-transformer": "catalog:",
     "class-validator": "catalog:",

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "bowser": "2.12.1",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",
-    "dompurify": "3.3.3",
+    "dompurify": "3.4.1",
     "fuse.js": "7.0.0",
     "jiti": "1.21.7",
     "jotai": "2.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,8 +343,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       dompurify:
-        specifier: 3.3.3
-        version: 3.3.3
+        specifier: 3.4.1
+        version: 3.4.1
       fuse.js:
         specifier: 7.0.0
         version: 7.0.0
@@ -4908,8 +4908,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -11476,7 +11476,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.1
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -12845,7 +12845,7 @@ snapshots:
       '@babel/runtime': 7.26.10
       csstype: 3.1.3
 
-  dompurify@3.3.3:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,7 @@ overrides:
   express>path-to-regexp: 0.1.13
   nestjs-base-service>class-validator: 0.14.4
   nestjs-base-service>lodash: 4.18.1
+  axios>follow-redirects: 1.16.0
   '@aws-sdk/xml-builder>fast-xml-parser': 5.5.8
   flat-cache>flatted: 3.4.2
   minimatch>brace-expansion: 2.0.3
@@ -120,8 +121,8 @@ importers:
         specifier: 3.52.1
         version: 3.52.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@ts-rest/core@3.51.1(@types/node@25.3.0)(zod@3.25.76))(rxjs@7.8.2)(zod@3.25.76)
       axios:
-        specifier: 1.15.0
-        version: 1.15.0
+        specifier: 1.15.2
+        version: 1.15.2
       bcrypt:
         specifier: 'catalog:'
         version: 6.0.0
@@ -3417,8 +3418,8 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/types@0.1.25':
-    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@t3-oss/env-core@0.10.1':
     resolution: {integrity: sha512-GcKZiCfWks5CTxhezn9k5zWX3sMDIYf6Kaxy2Gx9YEQftFcz8hDRN56hcbylyAO3t4jQnQ5ifLawINsNgCDpOg==}
@@ -4312,8 +4313,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5355,8 +5356,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -11233,7 +11234,7 @@ snapshots:
   '@swc/core@1.15.13':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.25
+      '@swc/types': 0.1.26
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.15.13
       '@swc/core-darwin-x64': 1.15.13
@@ -11254,7 +11255,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/types@0.1.25':
+  '@swc/types@0.1.26':
     dependencies:
       '@swc/counter': 0.1.3
     optional: true
@@ -12230,9 +12231,9 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.0:
+  axios@1.15.2:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -13598,7 +13599,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,8 @@ overrides:
   "express>path-to-regexp": "0.1.13"
   "nestjs-base-service>class-validator": "0.14.4"
   "nestjs-base-service>lodash": "4.18.1"
+  # axios ships stale follow-redirects 1.15.11 in lockfile (GHSA-r4q5-vmmm-2653)
+  "axios>follow-redirects": "1.16.0"
   # @aws-sdk/xml-builder@3.972.8 ships vulnerable fast-xml-parser 5.3.6 (GHSA-8gc5-j5rx-235r)
   "@aws-sdk/xml-builder>fast-xml-parser": "5.5.8"
   # Dev-only transitive overrides — parents don't ship patched versions yet


### PR DESCRIPTION
## Summary
- Upgrade **dompurify** `3.3.3` → `3.4.1` to fix FORBID_TAGS bypass via ADD_TAGS short-circuit ([GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp))
- Upgrade **axios** `1.15.0` → `1.15.2` and add scoped override `axios>follow-redirects` → `1.16.0` to fix auth header leak on cross-domain redirects ([GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653))

Both are moderate severity, production dependencies. Each fix is an atomic commit, independently revertable.

## Test plan
- [x] `pnpm audit` returns 0 vulnerabilities
- [x] Client tests pass (123/123)
- [x] API unit tests pass (26/26)
- [ ] Verify API HTTP requests follow redirects correctly in staging
- [ ] Verify client HTML sanitization works as expected