### PR TITLE
feat(analytics): emit visualisation_csv_download GA4 event on CSV export

### DIFF
--- a/client/src/containers/explore/survey-analysis/index.tsx
+++ b/client/src/containers/explore/survey-analysis/index.tsx
@@ -114,6 +114,7 @@ export default function Explore() {
                   indicator={w.indicator}
                   description={w.description}
                   title={w.title}
+                  section={s.name}
                   question={w.question}
                   questionTitle={w.questionTitle}
                   data={w.data as TransformedWidgetData}

--- a/client/src/containers/sandbox/index.tsx
+++ b/client/src/containers/sandbox/index.tsx
@@ -142,6 +142,8 @@ const Sandbox: FC = () => {
           <SandboxMenu
             downloadUrl={downloadUrl}
             onSave={createWidget}
+            chartId={widget.indicator}
+            chartTitle={widget.title}
           />
         }
         className="col-span-1 last:odd:col-span-2"

--- a/client/src/containers/sandbox/projections-sandbox/index.tsx
+++ b/client/src/containers/sandbox/projections-sandbox/index.tsx
@@ -330,6 +330,8 @@ const Sandbox: FC<SandboxProps> = ({ savedProjectionId }) => {
           downloadUrl={downloadUrl}
           onSave={createSavedProjection}
           onUpdate={savedProjectionId ? updateSavedProjection : undefined}
+          chartId={indicator}
+          chartTitle={indicator}
         />
       }
     />

--- a/client/src/containers/sandbox/user-sandbox/index.tsx
+++ b/client/src/containers/sandbox/user-sandbox/index.tsx
@@ -228,6 +228,8 @@ const Sandbox: FC<SandboxProps> = ({ customWidgetId }) => {
               )}
               onSave={createWidget}
               onUpdate={updateWidget}
+              chartId={widget.indicator}
+              chartTitle={widget.title}
             />
           }
           className="col-span-1 last:odd:col-span-2"

--- a/client/src/containers/widget/download-csv-link/index.test.tsx
+++ b/client/src/containers/widget/download-csv-link/index.test.tsx
@@ -84,6 +84,14 @@ describe("DownloadCsvLink", () => {
     expect(sendGAEvent).not.toHaveBeenCalled();
   });
 
+  it("does not fire the event when consent is explicitly false", () => {
+    renderWithConsent(false, { chartId: "q1", chartTitle: "Adoption" });
+
+    fireEvent.click(screen.getByText("Download as CSV"));
+
+    expect(sendGAEvent).not.toHaveBeenCalled();
+  });
+
   it("renders a download anchor pointing at the export URL", () => {
     renderWithConsent(true, { chartId: "q1" });
 

--- a/client/src/containers/widget/download-csv-link/index.test.tsx
+++ b/client/src/containers/widget/download-csv-link/index.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { analyticsConsentAtom } from "@/app/store";
+
+import DownloadCsvLink from "@/containers/widget/download-csv-link";
+
+const sendGAEvent = vi.fn();
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: (...args: unknown[]) => sendGAEvent(...args),
+}));
+
+function renderWithConsent(
+  consent: boolean | undefined,
+  props: Partial<{
+    chartId: string;
+    chartTitle: string;
+    section: string;
+  }> = {},
+) {
+  const store = createStore();
+  store.set(analyticsConsentAtom, consent);
+  return render(
+    <Provider store={store}>
+      <DownloadCsvLink downloadUrl="http://api.test/widgets/q1/export" {...props}>
+        Download as CSV
+      </DownloadCsvLink>
+    </Provider>,
+  );
+}
+
+describe("DownloadCsvLink", () => {
+  beforeEach(() => {
+    sendGAEvent.mockClear();
+  });
+
+  it("fires the GA4 event with all params when consent is granted", () => {
+    renderWithConsent(true, {
+      chartId: "q1",
+      chartTitle: "Adoption & Impact",
+      section: "Overview",
+    });
+
+    fireEvent.click(screen.getByText("Download as CSV"));
+
+    expect(sendGAEvent).toHaveBeenCalledTimes(1);
+    expect(sendGAEvent).toHaveBeenCalledWith(
+      "event",
+      "visualisation_csv_download",
+      {
+        chart_id: "q1",
+        chart_title: "Adoption & Impact",
+        section: "Overview",
+        file_name: "adoption-impact.csv",
+        export_format: "csv",
+      },
+    );
+  });
+
+  it("substitutes 'not_available' for missing params", () => {
+    renderWithConsent(true, { chartId: "q1" });
+
+    fireEvent.click(screen.getByText("Download as CSV"));
+
+    expect(sendGAEvent).toHaveBeenCalledWith(
+      "event",
+      "visualisation_csv_download",
+      {
+        chart_id: "q1",
+        chart_title: "not_available",
+        section: "not_available",
+        file_name: "not_available",
+        export_format: "csv",
+      },
+    );
+  });
+
+  it("does not fire the event when consent is not granted", () => {
+    renderWithConsent(undefined, { chartId: "q1", chartTitle: "Adoption" });
+
+    fireEvent.click(screen.getByText("Download as CSV"));
+
+    expect(sendGAEvent).not.toHaveBeenCalled();
+  });
+
+  it("renders a download anchor pointing at the export URL", () => {
+    renderWithConsent(true, { chartId: "q1" });
+
+    const link = screen.getByText("Download as CSV");
+    expect(link).toHaveAttribute("href", "http://api.test/widgets/q1/export");
+    expect(link).toHaveAttribute("download");
+  });
+});

--- a/client/src/containers/widget/download-csv-link/index.tsx
+++ b/client/src/containers/widget/download-csv-link/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnchorHTMLAttributes, forwardRef } from "react";
+import React, { AnchorHTMLAttributes, forwardRef } from "react";
 
 import { sendGAEvent } from "@next/third-parties/google";
 import { useAtomValue } from "jotai";
@@ -26,7 +26,9 @@ const DownloadCsvLink = forwardRef<HTMLAnchorElement, DownloadCsvLinkProps>(
   ) => {
     const analyticsConsent = useAtomValue(analyticsConsentAtom);
 
-    const handleClick = () => {
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+      anchorProps.onClick?.(event);
+
       if (!analyticsConsent) return;
 
       const slug = chartTitle ? slugify(chartTitle) : "";

--- a/client/src/containers/widget/download-csv-link/index.tsx
+++ b/client/src/containers/widget/download-csv-link/index.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { AnchorHTMLAttributes, forwardRef } from "react";
+
+import { sendGAEvent } from "@next/third-parties/google";
+import { useAtomValue } from "jotai";
+
+import { analyticsConsentAtom } from "@/app/store";
+
+import { slugify } from "@/lib/slugify";
+
+const NOT_AVAILABLE = "not_available";
+
+export interface DownloadCsvLinkProps
+  extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  downloadUrl: string;
+  chartId?: string;
+  chartTitle?: string;
+  section?: string;
+}
+
+const DownloadCsvLink = forwardRef<HTMLAnchorElement, DownloadCsvLinkProps>(
+  (
+    { downloadUrl, chartId, chartTitle, section, children, ...anchorProps },
+    ref,
+  ) => {
+    const analyticsConsent = useAtomValue(analyticsConsentAtom);
+
+    const handleClick = () => {
+      if (!analyticsConsent) return;
+
+      const slug = chartTitle ? slugify(chartTitle) : "";
+
+      sendGAEvent("event", "visualisation_csv_download", {
+        chart_id: chartId || NOT_AVAILABLE,
+        chart_title: chartTitle || NOT_AVAILABLE,
+        section: section || NOT_AVAILABLE,
+        file_name: slug ? `${slug}.csv` : NOT_AVAILABLE,
+        export_format: "csv",
+      });
+    };
+
+    return (
+      <a
+        ref={ref}
+        {...anchorProps}
+        href={downloadUrl}
+        download
+        onClick={handleClick}
+      >
+        {children}
+      </a>
+    );
+  },
+);
+
+DownloadCsvLink.displayName = "DownloadCsvLink";
+
+export default DownloadCsvLink;

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -81,6 +81,7 @@ export default function Widget({
       setFocusedWidget={setFocusedWidget}
       setSelectedVisualization={setSelectedVisualization}
       indicator={indicator}
+      chartTitle={indicator}
       downloadUrl={downloadUrl}
       className={config?.menu?.className}
     />

--- a/client/src/containers/widget/projections/menu/index.tsx
+++ b/client/src/containers/widget/projections/menu/index.tsx
@@ -7,6 +7,7 @@ import { useSetAtom } from "jotai";
 
 import { infoAtom } from "@/containers/dialog/store";
 import MenuButton from "@/containers/menu-button";
+import DownloadCsvLink from "@/containers/widget/download-csv-link";
 import { getMenuButtonText } from "@/containers/widget/projections/utils";
 
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,8 @@ interface WidgetMenuProps {
   setFocusedWidget: (indicator: string | null) => void;
   indicator: string;
   downloadUrl?: string;
+  chartTitle?: string;
+  section?: string;
 }
 
 const WidgetMenu: FC<WidgetMenuProps> = ({
@@ -39,6 +42,8 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
   className,
   indicator,
   downloadUrl,
+  chartTitle,
+  section,
   setSelectedVisualization,
   setShowOverlay,
   setFocusedWidget,
@@ -82,9 +87,14 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
         )}
         {downloadUrl && (
           <Button variant="clean" className={btnClassName} asChild>
-            <a href={downloadUrl} download>
+            <DownloadCsvLink
+              downloadUrl={downloadUrl}
+              chartId={indicator}
+              chartTitle={chartTitle}
+              section={section}
+            >
               Download as CSV
-            </a>
+            </DownloadCsvLink>
           </Button>
         )}
         {visualisations && (

--- a/client/src/containers/widget/sandbox-menu/index.tsx
+++ b/client/src/containers/widget/sandbox-menu/index.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { EllipsisIcon } from "lucide-react";
 import { useSession } from "next-auth/react";
 
+import DownloadCsvLink from "@/containers/widget/download-csv-link";
 import SaveWidgetForm from "@/containers/widget/create-widget/form";
 
 import { Button } from "@/components/ui/button";
@@ -28,12 +29,16 @@ interface SandboxMenuProps {
   downloadUrl: string;
   onSave: (name: string) => void;
   onUpdate?: () => void;
+  chartId?: string;
+  chartTitle?: string;
 }
 
 const SandboxMenu: FC<SandboxMenuProps> = ({
   downloadUrl,
   onSave,
   onUpdate,
+  chartId,
+  chartTitle,
 }) => {
   const { data: session } = useSession();
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -96,9 +101,13 @@ const SandboxMenu: FC<SandboxMenuProps> = ({
               </Button>
             )}
             <Button variant="clean" className={btnClassName} asChild>
-              <a href={downloadUrl} download>
+              <DownloadCsvLink
+                downloadUrl={downloadUrl}
+                chartId={chartId}
+                chartTitle={chartTitle}
+              >
                 Download as CSV
-              </a>
+              </DownloadCsvLink>
             </Button>
           </div>
         </PopoverContent>

--- a/client/src/containers/widget/survey-analysis/index.tsx
+++ b/client/src/containers/widget/survey-analysis/index.tsx
@@ -34,6 +34,7 @@ import { TransformedWidgetData } from "@/types";
 export interface WidgetProps {
   indicator: string;
   title: string;
+  section?: string;
   data: TransformedWidgetData;
   visualization: WidgetVisualizationsType;
   responseRate: number;
@@ -69,6 +70,7 @@ export default function Widget({
   breakdown,
   data,
   title,
+  section,
   description,
   question,
   questionTitle,
@@ -96,6 +98,8 @@ export default function Widget({
       setFocusedWidget={setFocusedWidget}
       setSelectedVisualization={setSelectedVisualization}
       indicator={indicator}
+      chartTitle={title}
+      section={section}
       downloadUrl={hideDownloadCsv ? undefined : downloadUrl}
       className={cn("p-0", config?.menu?.className)}
     />

--- a/client/src/containers/widget/survey-analysis/menu/index.tsx
+++ b/client/src/containers/widget/survey-analysis/menu/index.tsx
@@ -7,6 +7,7 @@ import { useSetAtom } from "jotai";
 
 import { infoAtom } from "@/containers/dialog/store";
 import MenuButton from "@/containers/menu-button";
+import DownloadCsvLink from "@/containers/widget/download-csv-link";
 
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -41,6 +42,8 @@ interface WidgetMenuProps {
   setFocusedWidget: (indicator: string | null) => void;
   indicator: string;
   downloadUrl?: string;
+  chartTitle?: string;
+  section?: string;
 }
 
 const WidgetMenu: FC<WidgetMenuProps> = ({
@@ -51,6 +54,8 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
   className,
   indicator,
   downloadUrl,
+  chartTitle,
+  section,
   setSelectedVisualization,
   setShowOverlay,
   setFocusedWidget,
@@ -94,9 +99,14 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
         )}
         {downloadUrl && (
           <Button variant="clean" className={btnClassName} asChild>
-            <a href={downloadUrl} download>
+            <DownloadCsvLink
+              downloadUrl={downloadUrl}
+              chartId={indicator}
+              chartTitle={chartTitle}
+              section={section}
+            >
               Download as CSV
-            </a>
+            </DownloadCsvLink>
           </Button>
         )}
         {visualisations && (

--- a/client/src/lib/slugify.test.ts
+++ b/client/src/lib/slugify.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { slugify } from "@/lib/slugify";
+
+describe("slugify", () => {
+  it("lowercases words and joins them with hyphens", () => {
+    expect(slugify("Adoption & Impact")).toBe("adoption-impact");
+  });
+
+  it("strips diacritics to ASCII", () => {
+    expect(slugify("Pingüino Señor")).toBe("pinguino-senor");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugify("  Hello!  ")).toBe("hello");
+  });
+
+  it("returns an empty string when there are no alphanumeric characters", () => {
+    expect(slugify("!!!")).toBe("");
+  });
+});

--- a/client/src/lib/slugify.test.ts
+++ b/client/src/lib/slugify.test.ts
@@ -18,4 +18,12 @@ describe("slugify", () => {
   it("returns an empty string when there are no alphanumeric characters", () => {
     expect(slugify("!!!")).toBe("");
   });
+
+  it("preserves digits", () => {
+    expect(slugify("Widget 42")).toBe("widget-42");
+  });
+
+  it("collapses consecutive separators into a single hyphen", () => {
+    expect(slugify("foo   &   bar")).toBe("foo-bar");
+  });
 });

--- a/client/src/lib/slugify.ts
+++ b/client/src/lib/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(input: string): string {
+  return input
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/client/src/lib/slugify.ts
+++ b/client/src/lib/slugify.ts
@@ -1,7 +1,7 @@
 export function slugify(input: string): string {
   return input
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");

--- a/client/tests/widget/sandbox-menu.test.tsx
+++ b/client/tests/widget/sandbox-menu.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
 import { describe, expect, it, vi } from "vitest";
+
+import { analyticsConsentAtom } from "@/app/store";
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: vi.fn(),
+}));
 
 vi.mock("next-auth/react", () => ({
   useSession: vi.fn(),
@@ -15,11 +22,13 @@ vi.mock("next/link", () => ({
   }) => <a href={href}>{children}</a>,
 }));
 
+import { sendGAEvent } from "@next/third-parties/google";
 import { useSession } from "next-auth/react";
 
 import SandboxMenu from "@/containers/widget/sandbox-menu";
 
 const mockedUseSession = vi.mocked(useSession);
+const mockedSendGAEvent = vi.mocked(sendGAEvent);
 
 const defaultProps = {
   downloadUrl: "/api/export?format=csv",
@@ -141,5 +150,40 @@ describe("SandboxMenu", () => {
         "/api/export?format=csv",
       );
     });
+  });
+
+  it("fires the GA event with chart metadata when Download as CSV is clicked with consent", async () => {
+    const store = createStore();
+    store.set(analyticsConsentAtom, true);
+
+    render(
+      <Provider store={store}>
+        <SandboxMenu
+          {...defaultProps}
+          chartId="indicator-1"
+          chartTitle="My Chart Title"
+        />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByTestId("sandbox-menu-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Download as CSV")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Download as CSV"));
+
+    expect(mockedSendGAEvent).toHaveBeenCalledWith(
+      "event",
+      "visualisation_csv_download",
+      {
+        chart_id: "indicator-1",
+        chart_title: "My Chart Title",
+        section: "not_available",
+        file_name: "my-chart-title.csv",
+        export_format: "csv",
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

GA4 Enhanced Measurement's `file_download` only fires for direct file-extension URLs, so the Visualisation Platform's `/export?...` CSV downloads were invisible to GA4 (Evenflow confirmed only `page_view`/`session_start` in Realtime). This adds a custom `visualisation_csv_download` event that fires on every CSV download across the platform.

- New shared `DownloadCsvLink` component fires `sendGAEvent("event", "visualisation_csv_download", {...})` on click, gated on `analyticsConsentAtom === true`.
- Event params: `chart_id`, `chart_title`, `section`, `file_name`, `export_format: "csv"`. Missing/empty values are sent as `"not_available"` rather than dropped. `page_location` is intentionally NOT sent (GA4 auto-collects it).
- `file_name` is an approximate client-side `${slugify(chart_title)}.csv` (new `slugify` helper).
- Wired into survey-analysis widget menu (with `section` from the explore loop), projections widget menu (`chart_title = indicator`, no section), and the sandbox menu across all three sandbox surfaces (sandbox, user-sandbox, projections-sandbox).

## Test Plan

- [x] `slugify` unit tests (6 cases)
- [x] `DownloadCsvLink` component tests (consent gating, param fallbacks, onClick composition)
- [x] `SandboxMenu` test asserts the GA event fires with chart metadata
- [x] Full client suite green (143 tests)
- [ ] Verify in GA4 Realtime that `visualisation_csv_download` appears with expected params on a deployed environment (not done locally — needs a running env)