### PR TITLE
feat(analytics): add visualisation type, file extension and page location to CSV download event

### DIFF
--- a/client/src/containers/sandbox/index.tsx
+++ b/client/src/containers/sandbox/index.tsx
@@ -144,6 +144,8 @@ const Sandbox: FC = () => {
             onSave={createWidget}
             chartId={widget.indicator}
             chartTitle={widget.title}
+            section="survey-analysis-sandbox"
+            visualisationType={visualization || widget.defaultVisualization}
           />
         }
         className="col-span-1 last:odd:col-span-2"

--- a/client/src/containers/sandbox/projections-sandbox/index.tsx
+++ b/client/src/containers/sandbox/projections-sandbox/index.tsx
@@ -332,6 +332,8 @@ const Sandbox: FC<SandboxProps> = ({ savedProjectionId }) => {
           onUpdate={savedProjectionId ? updateSavedProjection : undefined}
           chartId={indicator}
           chartTitle={indicator}
+          section="projections-sandbox"
+          visualisationType={visualization}
         />
       }
     />

--- a/client/src/containers/sandbox/user-sandbox/index.tsx
+++ b/client/src/containers/sandbox/user-sandbox/index.tsx
@@ -230,6 +230,8 @@ const Sandbox: FC<SandboxProps> = ({ customWidgetId }) => {
               onUpdate={updateWidget}
               chartId={widget.indicator}
               chartTitle={widget.title}
+              section="survey-analysis-sandbox"
+              visualisationType={visualization || widget.defaultVisualization}
             />
           }
           className="col-span-1 last:odd:col-span-2"

--- a/client/src/containers/widget/download-csv-link/index.test.tsx
+++ b/client/src/containers/widget/download-csv-link/index.test.tsx
@@ -17,6 +17,7 @@ function renderWithConsent(
     chartId: string;
     chartTitle: string;
     section: string;
+    visualisationType: string;
   }> = {},
 ) {
   const store = createStore();
@@ -40,6 +41,7 @@ describe("DownloadCsvLink", () => {
       chartId: "q1",
       chartTitle: "Adoption & Impact",
       section: "Overview",
+      visualisationType: "horizontal_bar_chart",
     });
 
     fireEvent.click(screen.getByText("Download as CSV"));
@@ -52,8 +54,11 @@ describe("DownloadCsvLink", () => {
         chart_id: "q1",
         chart_title: "Adoption & Impact",
         section: "Overview",
+        visualisation_type: "horizontal_bar_chart",
         file_name: "adoption-impact.csv",
+        file_extension: "csv",
         export_format: "csv",
+        page_location: window.location.href,
       },
     );
   });
@@ -70,8 +75,11 @@ describe("DownloadCsvLink", () => {
         chart_id: "q1",
         chart_title: "not_available",
         section: "not_available",
+        visualisation_type: "not_available",
         file_name: "not_available",
+        file_extension: "csv",
         export_format: "csv",
+        page_location: window.location.href,
       },
     );
   });

--- a/client/src/containers/widget/download-csv-link/index.tsx
+++ b/client/src/containers/widget/download-csv-link/index.tsx
@@ -17,11 +17,20 @@ export interface DownloadCsvLinkProps
   chartId?: string;
   chartTitle?: string;
   section?: string;
+  visualisationType?: string;
 }
 
 const DownloadCsvLink = forwardRef<HTMLAnchorElement, DownloadCsvLinkProps>(
   (
-    { downloadUrl, chartId, chartTitle, section, children, ...anchorProps },
+    {
+      downloadUrl,
+      chartId,
+      chartTitle,
+      section,
+      visualisationType,
+      children,
+      ...anchorProps
+    },
     ref,
   ) => {
     const analyticsConsent = useAtomValue(analyticsConsentAtom);
@@ -37,8 +46,11 @@ const DownloadCsvLink = forwardRef<HTMLAnchorElement, DownloadCsvLinkProps>(
         chart_id: chartId || NOT_AVAILABLE,
         chart_title: chartTitle || NOT_AVAILABLE,
         section: section || NOT_AVAILABLE,
+        visualisation_type: visualisationType || NOT_AVAILABLE,
         file_name: slug ? `${slug}.csv` : NOT_AVAILABLE,
+        file_extension: "csv",
         export_format: "csv",
+        page_location: window.location.href,
       });
     };
 

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -82,6 +82,7 @@ export default function Widget({
       setSelectedVisualization={setSelectedVisualization}
       indicator={indicator}
       chartTitle={indicator}
+      section="projections"
       downloadUrl={downloadUrl}
       className={config?.menu?.className}
     />

--- a/client/src/containers/widget/projections/menu/index.tsx
+++ b/client/src/containers/widget/projections/menu/index.tsx
@@ -92,6 +92,7 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
               chartId={indicator}
               chartTitle={chartTitle}
               section={section}
+              visualisationType={selectedVisualization}
             >
               Download as CSV
             </DownloadCsvLink>

--- a/client/src/containers/widget/sandbox-menu/index.tsx
+++ b/client/src/containers/widget/sandbox-menu/index.tsx
@@ -31,6 +31,8 @@ interface SandboxMenuProps {
   onUpdate?: () => void;
   chartId?: string;
   chartTitle?: string;
+  section?: string;
+  visualisationType?: string;
 }
 
 const SandboxMenu: FC<SandboxMenuProps> = ({
@@ -39,6 +41,8 @@ const SandboxMenu: FC<SandboxMenuProps> = ({
   onUpdate,
   chartId,
   chartTitle,
+  section,
+  visualisationType,
 }) => {
   const { data: session } = useSession();
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -105,6 +109,8 @@ const SandboxMenu: FC<SandboxMenuProps> = ({
                 downloadUrl={downloadUrl}
                 chartId={chartId}
                 chartTitle={chartTitle}
+                section={section}
+                visualisationType={visualisationType}
               >
                 Download as CSV
               </DownloadCsvLink>

--- a/client/src/containers/widget/survey-analysis/menu/index.tsx
+++ b/client/src/containers/widget/survey-analysis/menu/index.tsx
@@ -104,6 +104,7 @@ const WidgetMenu: FC<WidgetMenuProps> = ({
               chartId={indicator}
               chartTitle={chartTitle}
               section={section}
+              visualisationType={selectedVisualization}
             >
               Download as CSV
             </DownloadCsvLink>

--- a/client/tests/widget/sandbox-menu.test.tsx
+++ b/client/tests/widget/sandbox-menu.test.tsx
@@ -39,7 +39,16 @@ describe("SandboxMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedUseSession.mockReturnValue({
-      data: { user: { id: "1" }, accessToken: "token", expires: "" },
+      data: {
+        user: {
+          id: "1",
+          email: "user@example.com",
+          createdAt: new Date(0),
+          customWidgets: [],
+        },
+        accessToken: "token",
+        expires: "",
+      },
       status: "authenticated",
       update: vi.fn(),
     });
@@ -162,6 +171,8 @@ describe("SandboxMenu", () => {
           {...defaultProps}
           chartId="indicator-1"
           chartTitle="My Chart Title"
+          section="survey-analysis-sandbox"
+          visualisationType="horizontal_bar_chart"
         />
       </Provider>,
     );
@@ -180,9 +191,12 @@ describe("SandboxMenu", () => {
       {
         chart_id: "indicator-1",
         chart_title: "My Chart Title",
-        section: "not_available",
+        section: "survey-analysis-sandbox",
+        visualisation_type: "horizontal_bar_chart",
         file_name: "my-chart-title.csv",
+        file_extension: "csv",
         export_format: "csv",
+        page_location: window.location.href,
       },
     );
   });


### PR DESCRIPTION
## What

Follow-up to SIRH-405. Adds three dimensions to the `visualisation_csv_download` GA4 event:

- `visualisation_type` — the chart's selected/default visualization
- `file_extension` — `"csv"`
- `page_location` — `window.location.href`

`visualisationType` is threaded through `DownloadCsvLink` and every consumer: survey-analysis menu, projections menu, the shared `SandboxMenu`, and all three sandbox containers (survey-analysis, user, projections).

## Why

Richer GA4 reporting on CSV exports — field names confirmed against the SIRH-405 analytics event spec.

## Testing

- `download-csv-link` and `sandbox-menu` specs updated and passing (14 tests).
- Full client suite green (143 tests).
- Backfilled the `UserDto` session mock in `sandbox-menu.test.tsx` (pre-existing `tsc` error in a file this PR touches).

## Notes

- A separate pre-existing `tsc` error in `.next/types/app/layout.ts` (`isMobileDevice` export) remains on `dev` and is out of scope here.