### PR TITLE
fix(projections): scale penetration values by 100 at ingest (fraction  → percentage))

### DIFF
--- a/api/data/projections/projections.parser.ts
+++ b/api/data/projections/projections.parser.ts
@@ -111,7 +111,10 @@ const parseFromFile = async (
 
     for (let i = col.yearStart; i <= col.yearEnd; i++) {
       const year = 2020 + (i - col.yearStart);
-      const value = Number.parseFloat(row[i]);
+      const rawValue = Number.parseFloat(row[i]);
+      // Penetration arrives as a fraction (0–1); scale to percentage points for display
+      const value =
+        type === PROJECTION_TYPES.PENETRATION ? rawValue * 100 : rawValue;
       projectionData.push({
         projection: { id } as Projection,
         year,


### PR DESCRIPTION
## fix(projections): correct Penetration widget axis — scale values from fraction to percentage
                                                                                                                                                                                                                                     
  ### Overview
  
  The Penetration projection type was storing values as fractions (e.g. `0.31`) in the source CSVs while the unit was already `%`. This caused the chart, table, and CSV export to display `0.31%` instead of the correct `31%`.
  
  Fixed by multiplying penetration values by 100 in `api/data/projections/projections.parser.ts` at ingest time. All consumers (chart, table, CSV export) are corrected automatically since they all read from the same DB values. No frontend changes needed.   

  `projections.json` has been regenerated with the corrected values so the fix takes effect immediately on deploy, without waiting for the weekly ETL cron.
  
  ### Designs

  N/A — values-only fix, no visual layout changes.

  ### Testing instructions                                                                                                                                                                                                           

  1. Deploy to dev and wait for the API to start (data reload runs automatically on boot).
  2. Go to the **Projections** section and open the **Penetration** widget.
  3. Verify values now read as whole percentages (e.g. `31%`) instead of fractions (e.g. `0.31%`).
  4. Switch to the **Table** view and confirm the same values are correct there.
  5. Download the CSV export and verify the Penetration column contains percentage-scale numbers.
  
  > **Note:** A small number of projections (72 rows) display values above 100%. This is not caused by this fix — those values were already above 1.0 in the source CSVs and reflect valid market modelling scenarios where penetration exceeds the original addressable market estimate 


### Feature relevant tickets

https://vizzuality.atlassian.net/browse/SIRH-416
