### PR TITLE
fix(data-source): hide data-source filter when automated mock data is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ The ETL process runs automatically every Sunday at 3:00 AM via a scheduled cron 
 
 When the ETL process completes (successfully or with errors), email notifications are sent to configured recipients via the `ETL_PROCESS_EMAILS` environment variable.
 
+### Automated mock data
+
+`SEED_AUTOMATED_MOCK_DATA` controls two things together:
+
+1. Whether a sample of survey rows is cloned with `data_source = 'automated'` on initial data load.
+2. Whether the **Data source** page filter (`survey` / `automated`) is served by `GET /filters`, and therefore whether it appears in the client's filter UI.
+
+Both are driven by the same flag because the filter is only meaningful where the automated rows exist — otherwise selecting `automated` would return no results.
+
+It is enabled on dev and staging, and intentionally left unset in production, where it falls back to `false`.
+
 ### Manual ETL Execution
 
 You can run the ETL process manually using these scripts in the `api` package:

--- a/api/src/infrastructure/postgres-survey-answers.repository.ts
+++ b/api/src/infrastructure/postgres-survey-answers.repository.ts
@@ -16,6 +16,7 @@ import { WidgetUtils } from '@shared/dto/widgets/widget.utils';
 import { SurveyAnswer } from '@shared/dto/surveys/survey-answer.entity';
 import { SEARCH_FILTERS_OPERATORS } from '@shared/dto/global/search-filters';
 import { WIDGET_VISUALIZATIONS } from '@shared/dto/widgets/widget-visualizations.constants';
+import { DATA_SOURCE_FILTER_NAME } from '@shared/constants/page-filters';
 
 export class PostgresSurveyAnswerRepository
   extends Repository<SurveyAnswer>
@@ -168,7 +169,9 @@ export class PostgresSurveyAnswerRepository
       mapFilters.push(countriesFilter);
     }
 
-    const dataSourceFilter = filters?.find((f) => f.name === 'data-source');
+    const dataSourceFilter = filters?.find(
+      (f) => f.name === DATA_SOURCE_FILTER_NAME,
+    );
     if (dataSourceFilter) {
       mapFilters.push(dataSourceFilter);
     }

--- a/api/src/infrastructure/sql-adapter.ts
+++ b/api/src/infrastructure/sql-adapter.ts
@@ -1,6 +1,7 @@
 import { WidgetDataFilter } from '@shared/dto/widgets/widget-data-filter';
 import { Injectable, Logger } from '@nestjs/common';
 import { CountryISOMap } from '@shared/constants/country-iso.map';
+import { DATA_SOURCE_FILTER_NAME } from '@shared/constants/page-filters';
 
 export type FilterClauseWithParams = [sqlCode: string, queryParams: unknown[]];
 
@@ -72,7 +73,7 @@ export class SQLAdapter {
       }
 
       // data-source edge case — maps to the data_source column, not a question/answer pair
-      if (filter.name === 'data-source') {
+      if (filter.name === DATA_SOURCE_FILTER_NAME) {
         filterClause += '(';
         for (const filterValue of filter.values) {
           filterClause += `${alias}data_source ${filter.operator} $${++currentParamIdx} OR `;
@@ -122,7 +123,7 @@ export class SQLAdapter {
       }
 
       // data-source edge case — maps to the data_source column (hyphen not valid in SQL identifier)
-      if (filter.name === 'data-source') {
+      if (filter.name === DATA_SOURCE_FILTER_NAME) {
         filterClause += '(';
         for (const filterValue of filter.values) {
           filterClause += `${alias}data_source ${filter.operator} $${++currentParamIdx} OR `;

--- a/api/src/modules/widgets/page-filters.service.ts
+++ b/api/src/modules/widgets/page-filters.service.ts
@@ -13,6 +13,8 @@ import {
   ISurveyAnswerRepository,
   SurveyAnswerRepository,
 } from '@api/infrastructure/survey-answer-repository.interface';
+import { DATA_SOURCE_FILTER_NAME } from '@shared/constants/page-filters';
+import { AppConfig } from '@api/utils/app-config';
 
 @Injectable()
 export class PageFiltersService {
@@ -29,6 +31,14 @@ export class PageFiltersService {
     query: FetchSpecification & SearchFiltersDTO,
   ): Promise<PageFilter[]> {
     const availablePageFilters = await this.pageFilterRepository.find();
+
+    // The data-source filter is only meaningful where automated mock data was seeded.
+    if (!AppConfig.getBoolean('etl.seedAutomatedMockData', false)) {
+      return availablePageFilters.filter(
+        (f) => f.name !== DATA_SOURCE_FILTER_NAME,
+      );
+    }
+
     return availablePageFilters;
     // if (!query.filters) return availablePageFilters;
 

--- a/api/test/e2e/widgets/data-source-filter.spec.ts
+++ b/api/test/e2e/widgets/data-source-filter.spec.ts
@@ -1,6 +1,7 @@
 import { TestManager } from 'api/test/utils/test-manager';
 import { DataSourceManager } from '@api/infrastructure/data-source-manager';
 import { PageFilter } from '@shared/dto/widgets/page-filter.entity';
+import * as config from 'config';
 
 const TEST_SURVEYS_DATA_PATH = `${__dirname}/../../data/surveys.json`;
 
@@ -60,6 +61,31 @@ describe('data-source filter — API', () => {
       expect(dataSourceFilter.values).toEqual(
         expect.arrayContaining(['survey', 'automated']),
       );
+    });
+
+    it('should omit the data-source filter when automated mock data is disabled', async () => {
+      // The config instance is frozen, so the spy must target the prototype
+      const configPrototype = Object.getPrototypeOf(config);
+      const realGet = configPrototype.get;
+      jest
+        .spyOn(configPrototype, 'get')
+        .mockImplementation(function (this: unknown, key: string) {
+          return key === 'etl.seedAutomatedMockData'
+            ? false
+            : realGet.call(this, key);
+        });
+
+      try {
+        const res = await testManager.request().get('/filters');
+
+        expect(res.status).toBe(200);
+        expect(res.body.data.length).toBeGreaterThan(0);
+        expect(
+          res.body.data.find((f: PageFilter) => f.name === 'data-source'),
+        ).toBeUndefined();
+      } finally {
+        jest.restoreAllMocks();
+      }
     });
   });
 

--- a/shared/constants/page-filters.ts
+++ b/shared/constants/page-filters.ts
@@ -1,0 +1,1 @@
+export const DATA_SOURCE_FILTER_NAME = 'data-source';


### PR DESCRIPTION
## Summary

- The recent `data-source` filter feature (values `survey` / `automated`) served the filter from `GET /filters` unconditionally, while the automated mock rows behind the `automated` value are only seeded when `etl.seedAutomatedMockData` is true.
- Production leaves that flag unset (falls back to `false`), so it would have surfaced a "Data source" filter where selecting `automated` returns zero results on every widget.
- Gates `PageFiltersService.listFilters()` on the same flag that gates the seeding, so the filter is only offered where the data behind it exists (local/dev/staging keep it; production hides it).
- Extracted the `'data-source'` filter name into a shared constant (`shared/constants/page-filters.ts`) used by the query-building call sites in `sql-adapter.ts` and `postgres-survey-answers.repository.ts`.
- Documented the dual responsibility of `SEED_AUTOMATED_MOCK_DATA` in the README.

## Test plan

- [x] `pnpm check-types` / `pnpm lint` clean
- [x] New e2e case (`data-source-filter.spec.ts`) asserting the filter is omitted when the flag is off; confirmed it fails without the fix
- [x] Full API suite green: 94 unit / 60 integration / 26 e2e
- [x] Manual verification against a real Postgres with the flag toggled both ways — row present in `page_filters` throughout, `GET /filters` includes/excludes it in lockstep with the flag