### PR TITLE
feat(filters): explain the data sources behind the survey analysis filter

### DIFF
--- a/client/src/containers/bottom-bar/projections/filter-settings/button/index.tsx
+++ b/client/src/containers/bottom-bar/projections/filter-settings/button/index.tsx
@@ -6,8 +6,10 @@ import {
   DATA_SOURCE_FILTER_NAME,
   getDataSourceOptionLabel,
 } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
 import { useFilterSettings } from "@/containers/bottom-bar/filters-sheet/hooks";
+import DataSourceInfoButton from "@/containers/filter/data-source-info";
 import FilterSelect from "@/containers/filter/filter-select";
 import FilterItemButton from "@/containers/sidebar/filter-settings/button";
 
@@ -43,45 +45,53 @@ const FilterSettingsButton: FC<Props> = ({
 
   return (
     <>
-      <Button
-        variant="clean"
-        className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary"
-        onClick={() => setShowFilterSelect(true)}
-      >
-        {selectedFilter ? (
-          <>
-            <span className="inline-block">
-              {label?.selected ??
-                allFilters.find((f) => f.name === selectedFilter?.name)
-                  ?.label}{" "}
-              <FilterItemButton
-                value={selectedFilter.values[0]}
-                displayValue={
-                  isDataSource
-                    ? getDataSourceOptionLabel(selectedFilter.values)
-                    : undefined
-                }
-                removable={!isDataSource}
-                onClick={(value) => removeFilterValue(name, value)}
-              />
-            </span>
-            {!isDataSource && (
-              <ul>
-                {selectedFilter.values.slice(1).map((v) => (
-                  <li key={`selected-filter-${v}`}>
-                    <FilterItemButton
-                      value={v}
-                      onClick={(value) => removeFilterValue(name, value)}
-                    />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </>
-        ) : (
-          label?.unSelected || name
+      <div className="relative">
+        <Button
+          variant="clean"
+          className={cn(
+            "inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary",
+            isDataSource && "pr-10",
+          )}
+          onClick={() => setShowFilterSelect(true)}
+        >
+          {selectedFilter ? (
+            <>
+              <span className="inline-block">
+                {label?.selected ??
+                  allFilters.find((f) => f.name === selectedFilter?.name)
+                    ?.label}{" "}
+                <FilterItemButton
+                  value={selectedFilter.values[0]}
+                  displayValue={
+                    isDataSource
+                      ? getDataSourceOptionLabel(selectedFilter.values)
+                      : undefined
+                  }
+                  removable={!isDataSource}
+                  onClick={(value) => removeFilterValue(name, value)}
+                />
+              </span>
+              {!isDataSource && (
+                <ul>
+                  {selectedFilter.values.slice(1).map((v) => (
+                    <li key={`selected-filter-${v}`}>
+                      <FilterItemButton
+                        value={v}
+                        onClick={(value) => removeFilterValue(name, value)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : (
+            label?.unSelected || name
+          )}
+        </Button>
+        {isDataSource && (
+          <DataSourceInfoButton className="absolute right-4 top-1/2 -translate-y-1/2 text-white" />
         )}
-      </Button>
+      </div>
       <Sheet open={showFilterSelect} onOpenChange={setShowFilterSelect}>
         <SheetContent
           className="flex h-full max-h-[70%] w-screen flex-col justify-between overflow-hidden rounded-t-2xl bg-slate-100 p-0 text-background"

--- a/client/src/containers/filter/data-source-info/constants.ts
+++ b/client/src/containers/filter/data-source-info/constants.ts
@@ -1,0 +1,20 @@
+export const DATA_SOURCE_INFO_SECTIONS: {
+  heading?: string;
+  body: string;
+}[] = [
+  {
+    body: "The dashboard combines survey responses and automated website analysis to provide insights into the adoption of digital technologies across Europe’s agriculture and forestry sectors.",
+  },
+  {
+    heading: "Survey responses",
+    body: "Survey responses were collected in three waves between 2024 and 2026 through seven regional observatories across Europe. The agriculture-focused observatories were based in Spain, France, Benelux, Greece-Balkan, and Lithuania–Poland–Hungary, while the forestry-focused observatories were mostly based in Finland and Greece.",
+  },
+  {
+    heading: "Automated website analysis",
+    body: "Automated website analysis uses web scraping and AI-based information extraction to identify digital technology use in forestry from company websites. Results are evaluated for relevance, grounding, and consistency to ensure they reflect the original website content. The dataset contains observations from 2,438 organisations across 24 European countries.",
+  },
+  {
+    heading: "Survey and automated comparison",
+    body: "This comparison shows where survey responses and automated website analysis align or provide complementary insights. It is available only for forestry data and selected themes, including stakeholder profiles, adoption of digital technologies, technology integration, data management, and data sharing practices.",
+  },
+];

--- a/client/src/containers/filter/data-source-info/index.tsx
+++ b/client/src/containers/filter/data-source-info/index.tsx
@@ -1,0 +1,63 @@
+import { FC, Fragment, useState } from "react";
+
+import { HelpCircle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { DATA_SOURCE_INFO_SECTIONS } from "@/containers/filter/data-source-info/constants";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+interface DataSourceInfoButtonProps {
+  className?: string;
+}
+
+const DataSourceInfoButton: FC<DataSourceInfoButtonProps> = ({ className }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "rounded-full transition-opacity hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white",
+            className,
+          )}
+        >
+          <HelpCircle className="h-4 w-4" aria-hidden />
+          <span className="sr-only">About the data sources</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto] bg-white text-navy-950">
+        <DialogHeader>
+          <DialogTitle className="text-xl leading-12">Data sources</DialogTitle>
+        </DialogHeader>
+        <DialogDescription asChild>
+          <div className="space-y-2 overflow-y-auto text-xs text-[#627188]">
+            {DATA_SOURCE_INFO_SECTIONS.map(({ heading, body }) => (
+              <Fragment key={heading ?? "intro"}>
+                {heading && <p className="font-bold text-navy-950">{heading}</p>}
+                <p className="text-[#627188]">{body}</p>
+              </Fragment>
+            ))}
+          </div>
+        </DialogDescription>
+        <DialogFooter className="sm:justify-start">
+          <Button onClick={() => setOpen(false)}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DataSourceInfoButton;

--- a/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
@@ -7,9 +7,11 @@ import {
   DATA_SOURCE_FILTER_NAME,
   getDataSourceOptionLabel,
 } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
 import { FilterQueryParam } from "@/hooks/use-filters";
 
+import DataSourceInfoButton from "@/containers/filter/data-source-info";
 import FilterSelect from "@/containers/filter/filter-select";
 import { showOverlayAtom } from "@/containers/overlay/store";
 import FilterItemButton from "@/containers/sidebar/filter-settings/button";
@@ -53,75 +55,80 @@ const FilterPopup: FC<FilterPopupProps> = ({
   };
   const selectedFilter = filterQueryParams.find((f) => f.name === name);
   const isDataSource = name === DATA_SOURCE_FILTER_NAME;
-  // A single source needs no legend: there is nothing for the underlines to tell apart
   const isComparingSources =
     isDataSource && (selectedFilter?.values.length ?? 0) > 1;
 
   return (
-    <Popover onOpenChange={handleFiltersPopupChange} open={showPopup} modal>
-      <PopoverTrigger asChild>
-        <Button
-          variant="clean"
-          className="inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary"
-        >
-          {selectedFilter ? (
-            <>
-              <span className="inline-block">
-                {
-                  // This fix follows the previous pattern which covers differents use cases in a hacky way.
-                  label?.selected ??
-                    filters.find((f) => f.name === selectedFilter?.name)?.label
-                }{" "}
-                {isComparingSources ? (
-                  <DataSourceFilterLabel values={selectedFilter.values} />
-                ) : (
-                  <FilterItemButton
-                    value={selectedFilter.values[0]}
-                    displayValue={
-                      isDataSource
-                        ? getDataSourceOptionLabel(selectedFilter.values)
-                        : undefined
-                    }
-                    removable={!isDataSource}
-                    onClick={(value) => onRemoveFilterValue(name, value)}
-                  />
+    <div className="relative">
+      <Popover onOpenChange={handleFiltersPopupChange} open={showPopup} modal>
+        <PopoverTrigger asChild>
+          <Button
+            variant="clean"
+            className={cn(
+              "inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary",
+              isDataSource && "pr-10",
+            )}
+          >
+            {selectedFilter ? (
+              <>
+                <span className="inline-block">
+                  {label?.selected ??
+                    filters.find((f) => f.name === selectedFilter?.name)
+                      ?.label}{" "}
+                  {isComparingSources ? (
+                    <DataSourceFilterLabel values={selectedFilter.values} />
+                  ) : (
+                    <FilterItemButton
+                      value={selectedFilter.values[0]}
+                      displayValue={
+                        isDataSource
+                          ? getDataSourceOptionLabel(selectedFilter.values)
+                          : undefined
+                      }
+                      removable={!isDataSource}
+                      onClick={(value) => onRemoveFilterValue(name, value)}
+                    />
+                  )}
+                </span>
+                {!isDataSource && (
+                  <ul>
+                    {selectedFilter.values.slice(1).map((v) => (
+                      <li key={`selected-filter-${v}`}>
+                        <FilterItemButton
+                          value={v}
+                          onClick={(value) => onRemoveFilterValue(name, value)}
+                        />
+                      </li>
+                    ))}
+                  </ul>
                 )}
-              </span>
-              {!isDataSource && (
-                <ul>
-                  {selectedFilter.values.slice(1).map((v) => (
-                    <li key={`selected-filter-${v}`}>
-                      <FilterItemButton
-                        value={v}
-                        onClick={(value) => onRemoveFilterValue(name, value)}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </>
-          ) : (
-            label?.unSelected || name
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        side="bottom"
-        className={SIDEBAR_POPOVER_CLASS}
-      >
-        <FilterSelect
-          items={filters}
-          defaultValues={selectedFilter?.values || []}
-          fixedFilter={fixedFilter}
-          onSubmit={(values) => {
-            onAddFilter(values);
-            handleFiltersPopupChange(false);
-          }}
-          maxHeight={220}
-        />
-      </PopoverContent>
-    </Popover>
+              </>
+            ) : (
+              label?.unSelected || name
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          side="bottom"
+          className={SIDEBAR_POPOVER_CLASS}
+        >
+          <FilterSelect
+            items={filters}
+            defaultValues={selectedFilter?.values || []}
+            fixedFilter={fixedFilter}
+            onSubmit={(values) => {
+              onAddFilter(values);
+              handleFiltersPopupChange(false);
+            }}
+            maxHeight={220}
+          />
+        </PopoverContent>
+      </Popover>
+      {isDataSource && (
+        <DataSourceInfoButton className="absolute right-4 top-1/2 -translate-y-1/2 text-white" />
+      )}
+    </div>
   );
 };
 

--- a/client/tests/filter-settings/data-source-info-button.test.tsx
+++ b/client/tests/filter-settings/data-source-info-button.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import FilterPopup from "@/containers/sidebar/filter-settings/filter-popup";
+
+describe("Data source info button", () => {
+  const renderFilterPopup = () =>
+    render(
+      <FilterPopup
+        name="data-source"
+        label={{ selected: "Data is", unSelected: "Data source" }}
+        filters={[{ name: "data-source", label: "Data source", values: [] }]}
+        filterQueryParams={[
+          { name: "data-source", operator: "=", values: ["survey"] },
+        ]}
+        onAddFilter={vi.fn()}
+        onRemoveFilterValue={vi.fn()}
+      />,
+    );
+
+  it("opens the data sources dialog without opening the filter popover", async () => {
+    renderFilterPopup();
+    const filterTrigger = screen.getByRole("button", { name: /Data is/ });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "About the data sources" }),
+    );
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Data sources");
+    expect(filterTrigger).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
## What

Adds a help icon to the **data source** filter row that opens a **Data sources** dialog explaining what each source is.

The filter changes every number on the page, but nothing on screen said what "survey" and "automated" mean, how each was collected, or why the comparison view only covers some themes.

Figma: [sidebar row](https://www.figma.com/design/1MQAbB99h05eR5xbHqNDVn/4Growth--Internal-?node-id=8646-24074) · [dialog](https://www.figma.com/design/1MQAbB99h05eR5xbHqNDVn/4Growth--Internal-?node-id=8681-217916)

## How

- New `client/src/containers/filter/data-source-info/` — copy constants plus a self-contained `DataSourceInfoButton`. It lives under `containers/filter/` because both the desktop sidebar and the mobile bottom-sheet consume it.
- Wired into both the desktop sidebar row (`filter-settings/filter-popup`) and the mobile sheet row (`bottom-bar/projections/filter-settings/button`), gated on `isDataSource`.
- Renders in the single-source state as well as the comparison state — the copy explains all three options.

## Decisions worth reviewing

**The copy is a static client constant, not API-driven.** It does not vary by selection, so an API route would have meant a migration, a contract change, and an entity field for four paragraphs of editorial text. If the copy needs to change without a deploy, this is the decision to push back on.

**The icon is a sibling of the filter trigger, not nested inside it.** The row *is* the `PopoverTrigger` button. The existing precedent (`ScenarioInfoButton` inside an `AccordionTrigger`) nests a `div role="button"` and calls `stopPropagation`, which is not keyboard-reachable and is an invalid content model. Here the row is wrapped in a `relative` container and the icon is absolutely positioned alongside it, so it is a real `<button>` in natural tab order and its click never reaches the trigger. `PopoverContent` is portalled, so the new stacking context is harmless. Trade-off: hovering the icon no longer paints the row's `hover:bg-secondary`.

**New component rather than reusing `infoAtom` / `MoreInfoDialog`.** That pipeline takes an HTML string through `DOMPurify` + `dangerouslySetInnerHTML` because widget descriptions arrive from the API. Our copy is authored in the repo, so it stays JSX. What would have been reused is ~15 lines of dialog chrome.

No new dependencies. `HelpCircle` comes from `lucide-react`, already in use.

## Tests

One test: clicking the help icon opens the dialog **and leaves the filter popover closed**. It catches the regression of someone re-nesting the trigger inside the popover button, where the click would bubble and open the filter selector instead. Rendering static copy is not behaviour, so nothing else is asserted.

- `pnpm vitest run` — 29 files, 158 tests, all pass
- `pnpm check-types` — clean for these files (see below)

## Not done / flagged

- **Not run in a browser.** Visual checks against Figma (icon position relative to the legend underlines, focus return on Escape, the mobile sheet) are still open. The data source row only renders when the API's `etl.seedAutomatedMockData` is on.
- **`pnpm lint` fails on `dev` too, unrelated to this branch.** ESLint 10 is installed against `.eslintrc` + `.eslintignore`; `next lint` bails with `Invalid Options: Unknown options: useEslintrc, extensions, …` before reading a single file. These files could not be linted. Worth a separate ticket to migrate to `eslint.config.js`.
- **`pnpm check-types` reports one pre-existing error** in generated `.next/types/app/layout.ts`: `src/app/layout.tsx` exports `isMobileDevice`, which Next disallows for a layout module. Untouched by this branch.
- **The copy hardcodes figures** — "2,438 organisations across 24 European countries" and "three waves between 2024 and 2026". The ETL re-runs weekly and the automated source is still mock-seeded, so these will drift silently. Flagging for whoever owns the copy; deriving them would need a count endpoint the contract does not have.
- **Pre-existing divergence, out of scope:** the mobile row still never renders `DataSourceFilterLabel`, so it shows no comparison legend while desktop does.
