### PR TITLE
fix(filters): unblock the mobile filters button on survey analysis

### DIFF
--- a/client/src/app/(root)/projections/page.tsx
+++ b/client/src/app/(root)/projections/page.tsx
@@ -1,7 +1,7 @@
 import BottomBar from "@/containers/bottom-bar";
 import CategorySheet from "@/containers/bottom-bar/category-sheet";
-import FiltersSheet from "@/containers/bottom-bar/filters-sheet";
 import FilterSettings from "@/containers/bottom-bar/projections/filter-settings";
+import FiltersSheet from "@/containers/bottom-bar/projections/filters-sheet";
 import ScenariosSheet from "@/containers/bottom-bar/projections/scenarios-sheet";
 import Explore from "@/containers/explore/projections";
 import { PROJECTIONS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";

--- a/client/src/app/(root)/projections/sandbox/[id]/page.tsx
+++ b/client/src/app/(root)/projections/sandbox/[id]/page.tsx
@@ -10,8 +10,8 @@ import { auth } from "@/app/auth/api/[...nextauth]/config";
 
 import BottomBar from "@/containers/bottom-bar";
 import CategorySheet from "@/containers/bottom-bar/category-sheet";
-import FiltersSheet from "@/containers/bottom-bar/filters-sheet";
 import FilterSettings from "@/containers/bottom-bar/projections/filter-settings";
+import FiltersSheet from "@/containers/bottom-bar/projections/filters-sheet";
 import SettingsSheet from "@/containers/bottom-bar/projections/settings-sheet";
 import Sandbox from "@/containers/sandbox/projections-sandbox";
 import { PROJECTIONS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";

--- a/client/src/app/(root)/projections/sandbox/page.tsx
+++ b/client/src/app/(root)/projections/sandbox/page.tsx
@@ -5,8 +5,8 @@ import { queryKeys } from "@/lib/queryKeys";
 
 import BottomBar from "@/containers/bottom-bar";
 import CategorySheet from "@/containers/bottom-bar/category-sheet";
-import FiltersSheet from "@/containers/bottom-bar/filters-sheet";
 import FilterSettings from "@/containers/bottom-bar/projections/filter-settings";
+import FiltersSheet from "@/containers/bottom-bar/projections/filters-sheet";
 import SettingsSheet from "@/containers/bottom-bar/projections/settings-sheet";
 import Sandbox from "@/containers/sandbox/projections-sandbox";
 import { PROJECTIONS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";

--- a/client/src/containers/bottom-bar/filters-sheet/index.test.tsx
+++ b/client/src/containers/bottom-bar/filters-sheet/index.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, it, vi } from "vitest";
+
+import FiltersSheet from "@/containers/bottom-bar/filters-sheet";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/survey-analysis",
+}));
+
+function renderSheet(props: { disabled?: boolean } = {}) {
+  return render(
+    <NuqsTestingAdapter>
+      <Provider store={createStore()}>
+        <FiltersSheet {...props}>
+          <div />
+        </FiltersSheet>
+      </Provider>
+    </NuqsTestingAdapter>,
+  );
+}
+
+describe("FiltersSheet", () => {
+  it("leaves the trigger enabled when no gate is passed", () => {
+    renderSheet();
+
+    expect(screen.getByRole("button", { name: "Filters" })).toBeEnabled();
+  });
+
+  it("disables the trigger when the caller gates it", () => {
+    renderSheet({ disabled: true });
+
+    expect(screen.getByRole("button", { name: "Filters" })).toBeDisabled();
+  });
+});

--- a/client/src/containers/bottom-bar/filters-sheet/index.tsx
+++ b/client/src/containers/bottom-bar/filters-sheet/index.tsx
@@ -4,7 +4,6 @@ import { FC, PropsWithChildren, useEffect, useState } from "react";
 import { useAtom } from "jotai";
 import { useQueryState } from "nuqs";
 
-import useProjectionsCategoryFilter from "@/hooks/use-category-filter";
 import useFilters from "@/hooks/use-filters";
 
 import {
@@ -23,13 +22,14 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 
-const FiltersSheet: FC<PropsWithChildren> = ({ children }) => {
+type FiltersSheetProps = PropsWithChildren<{ disabled?: boolean }>;
+
+const FiltersSheet: FC<FiltersSheetProps> = ({ children, disabled }) => {
   const [open, setOpen] = useState(false);
   const { filters, setFilters } = useFilters();
   const [newFilters, setNewFilters] = useAtom(FilterSettingsAtom);
   const [newBreakdown, setNewBreakdown] = useAtom(breakdownAtom);
   const [breakdown, setBreakdown] = useQueryState("breakdown");
-  const { isCategorySelected } = useProjectionsCategoryFilter();
   const handleSubmitButtonClick = () => {
     setFilters(newFilters);
     setBreakdown(newBreakdown);
@@ -64,7 +64,7 @@ const FiltersSheet: FC<PropsWithChildren> = ({ children }) => {
       }}
     >
       <SheetTrigger asChild>
-        <Button disabled={!isCategorySelected} className="w-full">
+        <Button disabled={disabled} className="w-full">
           Filters
         </Button>
       </SheetTrigger>

--- a/client/src/containers/bottom-bar/projections/filters-sheet/index.tsx
+++ b/client/src/containers/bottom-bar/projections/filters-sheet/index.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { FC, PropsWithChildren } from "react";
+
+import useProjectionsCategoryFilter from "@/hooks/use-category-filter";
+
+import FiltersSheet from "@/containers/bottom-bar/filters-sheet";
+
+const ProjectionsFiltersSheet: FC<PropsWithChildren> = ({ children }) => {
+  const { isCategorySelected } = useProjectionsCategoryFilter();
+
+  return <FiltersSheet disabled={!isCategorySelected}>{children}</FiltersSheet>;
+};
+
+export default ProjectionsFiltersSheet;


### PR DESCRIPTION
## Problem

On mobile, the **Filters** button in the bottom bar of `/survey-analysis` and `/survey-analysis/sandbox` is permanently disabled, so the filter sheet is unreachable. Desktop is unaffected — that tree writes filters straight to the URL with no gating.

## Cause

`containers/bottom-bar/filters-sheet` is shared by five pages, but it hardcoded a projections-only gate on its trigger:

```tsx
const { isCategorySelected } = useProjectionsCategoryFilter();
<Button disabled={!isCategorySelected} className="w-full">Filters</Button>
```

`isCategorySelected` resolves to `!!filters.find(f => f.name === "category")`. A `category` filter is written in exactly one place — the projections category selector — and `sidebar/filter-settings` explicitly scopes `category` to projections. Survey analysis has no category selector, so the URL never carries one, the flag is permanently `false`, and because `SheetTrigger asChild` forwards onto the disabled `<Button>`, the Radix trigger never fires.

The gate is correct for projections: the desktop projections sidebar deliberately gates the same accordions, and the sibling `scenarios-sheet` and `settings-sheet` apply it legitimately. The bug was only that it lived inside a component five pages share.

## Change

- `bottom-bar/filters-sheet` takes a `disabled?: boolean` prop instead of calling the hook. Staging-buffer logic (`FilterSettingsAtom`, `breakdownAtom`, the open/close seeding effect, the Apply button) is untouched.
- New `bottom-bar/projections/filters-sheet` — a thin client wrapper deriving the gate, placed next to the `scenarios-sheet` and `settings-sheet` that gate the same way. The consuming pages are server components, so they can't compute it inline.
- The three projections pages import the wrapper; the two survey-analysis pages keep the shared sheet and are now enabled.

`survey-analysis/sandbox/[id]` already used a separate ungated variant and is unchanged.

## Test

`filters-sheet/index.test.tsx` asserts the trigger is enabled by default and disabled only when a caller gates it — which is exactly the regression that reintroducing a route-specific gate into the shared component would trip.

## Verification

- `pnpm test` — 160 passed / 30 files.
- `pnpm check-types` — one error in `.next/types/app/layout.ts` about `isMobileDevice`. Reproduced on a clean tree, so pre-existing and unrelated. No new errors.
- `pnpm lint` is broken repo-wide (`next lint` passes `useEslintrc`/`extensions`/`ignorePath` to an ESLint 9 that removed them) — pre-existing, worth a separate fix. Ran Prettier instead: all touched files clean.
- Manual pass at a viewport below `md` (the split is pure Tailwind, so resizing suffices): **not yet done** — please check `/survey-analysis` opens and applies filters, and that `/projections` still gates Filters until a category is picked.

## Out of scope

Two adjacent issues surfaced while tracing this, worth separate tickets:

- Both filter trees mount at every viewport (only CSS-hidden), firing duplicate `searchFilters` requests under different query keys — while `page-filters.service.ts` ignores `query.filters` entirely, so the refetch-per-change returns an identical list.
- The desktop and mobile `filter-settings` components are near-identical copy-paste.
