### PR TITLE
feat(data-source): lock the sector to forestry for automated data

### DIFF
--- a/client/src/containers/bottom-bar/projections/filter-settings/button/index.tsx
+++ b/client/src/containers/bottom-bar/projections/filter-settings/button/index.tsx
@@ -1,17 +1,21 @@
-import { FC, useState } from "react";
+import { FC, useId, useState } from "react";
 
 import { PageFilter } from "@shared/dto/widgets/page-filter.entity";
 
 import {
   DATA_SOURCE_FILTER_NAME,
+  SECTOR_FILTER_NAME,
   getDataSourceOptionLabel,
 } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+
+import { isSectorLocked } from "@/hooks/use-filters";
 
 import { useFilterSettings } from "@/containers/bottom-bar/filters-sheet/hooks";
 import DataSourceInfoButton from "@/containers/filter/data-source-info";
 import FilterSelect from "@/containers/filter/filter-select";
 import FilterItemButton from "@/containers/sidebar/filter-settings/button";
+import { LOCKED_SECTOR_REASON } from "@/containers/sidebar/filter-settings/constants";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -42,17 +46,27 @@ const FilterSettingsButton: FC<Props> = ({
   const { filters, removeFilterValue, addFilter } = useFilterSettings();
   const selectedFilter = filters.find((f) => f.name === name);
   const isDataSource = name === DATA_SOURCE_FILTER_NAME;
+  const locked = name === SECTOR_FILTER_NAME && isSectorLocked(filters);
+  const reasonId = useId();
 
   return (
     <>
       <div className="relative">
         <Button
           variant="clean"
+          aria-disabled={locked || undefined}
+          aria-describedby={locked ? reasonId : undefined}
+          title={locked ? LOCKED_SECTOR_REASON : undefined}
           className={cn(
             "inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary",
             isDataSource && "pr-10",
+            locked && "cursor-default opacity-60 hover:bg-transparent",
           )}
-          onClick={() => setShowFilterSelect(true)}
+          onClick={() => {
+            if (locked) return;
+
+            setShowFilterSelect(true);
+          }}
         >
           {selectedFilter ? (
             <>
@@ -67,7 +81,7 @@ const FilterSettingsButton: FC<Props> = ({
                       ? getDataSourceOptionLabel(selectedFilter.values)
                       : undefined
                   }
-                  removable={!isDataSource}
+                  removable={!isDataSource && !locked}
                   onClick={(value) => removeFilterValue(name, value)}
                 />
               </span>
@@ -90,6 +104,11 @@ const FilterSettingsButton: FC<Props> = ({
         </Button>
         {isDataSource && (
           <DataSourceInfoButton className="absolute right-4 top-1/2 -translate-y-1/2 text-white" />
+        )}
+        {locked && (
+          <span id={reasonId} className="sr-only">
+            {LOCKED_SECTOR_REASON}
+          </span>
         )}
       </div>
       <Sheet open={showFilterSelect} onOpenChange={setShowFilterSelect}>

--- a/client/src/containers/bottom-bar/survey-analysis/filters-sheet/user-sandbox/index.tsx
+++ b/client/src/containers/bottom-bar/survey-analysis/filters-sheet/user-sandbox/index.tsx
@@ -8,8 +8,8 @@ import {
   FilterSettingsAtom,
 } from "@/containers/bottom-bar/filters-sheet/store";
 import {
+  lockedSandboxFiltersAtom,
   sandboxBreakdownAtom,
-  sandboxFiltersAtom,
 } from "@/containers/sidebar/store";
 
 import { Button } from "@/components/ui/button";
@@ -25,7 +25,7 @@ import {
 
 const FiltersSheet: FC<PropsWithChildren> = ({ children }) => {
   const [open, setOpen] = useState(false);
-  const [filters, setFilters] = useAtom(sandboxFiltersAtom);
+  const [filters, setFilters] = useAtom(lockedSandboxFiltersAtom);
   const [newFilters, setNewFilters] = useAtom(FilterSettingsAtom);
   const [newBreakdown, setNewBreakdown] = useAtom(breakdownAtom);
   const [breakdown, setBreakdown] = useAtom(sandboxBreakdownAtom);

--- a/client/src/containers/bottom-bar/survey-analysis/settings-sheet/user-sandbox/index.tsx
+++ b/client/src/containers/bottom-bar/survey-analysis/settings-sheet/user-sandbox/index.tsx
@@ -14,7 +14,7 @@ import { queryKeys } from "@/lib/queryKeys";
 
 import IndicatorSelector from "@/containers/sidebar/indicator-seletor";
 import {
-  sandboxFiltersAtom,
+  lockedSandboxFiltersAtom,
   sandboxVisualizationAtom,
   sandboxIndicatorAtom,
   sandboxBreakdownAtom,
@@ -33,7 +33,7 @@ import {
 } from "@/components/ui/sheet";
 
 const SettingsSheet: FC = () => {
-  const filters = useAtomValue(sandboxFiltersAtom);
+  const filters = useAtomValue(lockedSandboxFiltersAtom);
   const [indicator, setIndicator] = useAtom(sandboxIndicatorAtom);
   const breakdown = useAtomValue(sandboxBreakdownAtom);
   const [visualization, setVisualization] = useAtom(sandboxVisualizationAtom);

--- a/client/src/containers/sandbox/user-sandbox/index.tsx
+++ b/client/src/containers/sandbox/user-sandbox/index.tsx
@@ -22,8 +22,8 @@ import { withDataSourceDefault } from "@/hooks/use-filters";
 import { buildWidgetDownloadUrl } from "@/utils/download-url";
 
 import {
+  lockedSandboxFiltersAtom,
   sandboxBreakdownAtom,
-  sandboxFiltersAtom,
   sandboxIndicatorAtom,
   sandboxVisualizationAtom,
 } from "@/containers/sidebar/store";
@@ -47,7 +47,7 @@ const Sandbox: FC<SandboxProps> = ({ customWidgetId }) => {
   const { redirect } = useAuthRedirect();
   const [indicator, setIndicator] = useAtom(sandboxIndicatorAtom);
   const [visualization, setVisualization] = useAtom(sandboxVisualizationAtom);
-  const [filters, setFilters] = useAtom(sandboxFiltersAtom);
+  const [filters, setFilters] = useAtom(lockedSandboxFiltersAtom);
   const breakdown = useAtomValue(sandboxBreakdownAtom);
   const getCustomWidgetQuery = client.users.findCustomWidget.useQuery(
     queryKeys.users.userChart(customWidgetId).queryKey,

--- a/client/src/containers/sidebar/filter-settings/constants.ts
+++ b/client/src/containers/sidebar/filter-settings/constants.ts
@@ -7,6 +7,9 @@ export const SURVEY_ANALYSIS_DEFAULT_FILTERS = [
   "sector",
 ];
 
+export const LOCKED_SECTOR_REASON =
+  "Automated website analysis covers forestry organisations only, so the sector is fixed to Forestry.";
+
 export const PROJECTIONS_DEFAULT_FILTERS = [
   "country",
   "technology-type",

--- a/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
+++ b/client/src/containers/sidebar/filter-settings/filter-popup/index.tsx
@@ -1,20 +1,22 @@
-import { FC, useState } from "react";
+import { FC, useId, useState } from "react";
 
 import { PageFilter } from "@shared/dto/widgets/page-filter.entity";
 import { useSetAtom } from "jotai";
 
 import {
   DATA_SOURCE_FILTER_NAME,
+  SECTOR_FILTER_NAME,
   getDataSourceOptionLabel,
 } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
-import { FilterQueryParam } from "@/hooks/use-filters";
+import { FilterQueryParam, isSectorLocked } from "@/hooks/use-filters";
 
 import DataSourceInfoButton from "@/containers/filter/data-source-info";
 import FilterSelect from "@/containers/filter/filter-select";
 import { showOverlayAtom } from "@/containers/overlay/store";
 import FilterItemButton from "@/containers/sidebar/filter-settings/button";
+import { LOCKED_SECTOR_REASON } from "@/containers/sidebar/filter-settings/constants";
 import DataSourceFilterLabel from "@/containers/sidebar/filter-settings/data-source-label";
 
 import { Button } from "@/components/ui/button";
@@ -49,14 +51,19 @@ const FilterPopup: FC<FilterPopupProps> = ({
 }) => {
   const [showPopup, setShowPopup] = useState(false);
   const setShowOverlay = useSetAtom(showOverlayAtom);
-  const handleFiltersPopupChange = (open: boolean) => {
-    setShowPopup(open);
-    setShowOverlay(open);
-  };
   const selectedFilter = filterQueryParams.find((f) => f.name === name);
   const isDataSource = name === DATA_SOURCE_FILTER_NAME;
   const isComparingSources =
     isDataSource && (selectedFilter?.values.length ?? 0) > 1;
+  const locked =
+    name === SECTOR_FILTER_NAME && isSectorLocked(filterQueryParams);
+  const reasonId = useId();
+  const handleFiltersPopupChange = (open: boolean) => {
+    if (locked && open) return;
+
+    setShowPopup(open);
+    setShowOverlay(open);
+  };
 
   return (
     <div className="relative">
@@ -64,9 +71,13 @@ const FilterPopup: FC<FilterPopupProps> = ({
         <PopoverTrigger asChild>
           <Button
             variant="clean"
+            aria-disabled={locked || undefined}
+            aria-describedby={locked ? reasonId : undefined}
+            title={locked ? LOCKED_SECTOR_REASON : undefined}
             className={cn(
               "inline-block h-full w-full whitespace-pre-wrap rounded-none px-4 py-3.5 text-left font-normal transition-colors hover:bg-secondary",
               isDataSource && "pr-10",
+              locked && "cursor-default opacity-60 hover:bg-transparent",
             )}
           >
             {selectedFilter ? (
@@ -85,7 +96,7 @@ const FilterPopup: FC<FilterPopupProps> = ({
                           ? getDataSourceOptionLabel(selectedFilter.values)
                           : undefined
                       }
-                      removable={!isDataSource}
+                      removable={!isDataSource && !locked}
                       onClick={(value) => onRemoveFilterValue(name, value)}
                     />
                   )}
@@ -127,6 +138,11 @@ const FilterPopup: FC<FilterPopupProps> = ({
       </Popover>
       {isDataSource && (
         <DataSourceInfoButton className="absolute right-4 top-1/2 -translate-y-1/2 text-white" />
+      )}
+      {locked && (
+        <span id={reasonId} className="sr-only">
+          {LOCKED_SECTOR_REASON}
+        </span>
       )}
     </div>
   );

--- a/client/src/containers/sidebar/store.ts
+++ b/client/src/containers/sidebar/store.ts
@@ -4,9 +4,19 @@ import { WidgetVisualizationsType } from "@shared/dto/widgets/widget-visualizati
 import { atom } from "jotai";
 import { useHydrateAtoms } from "jotai/utils";
 
-import { FilterQueryParam } from "@/hooks/use-filters";
+import { FilterQueryParam, withForestryLock } from "@/hooks/use-filters";
 
 export const sandboxFiltersAtom = atom<FilterQueryParam[]>([]);
+
+/**
+ * Saved sandboxes never pass through useFilters, so the read-time normalisation
+ * that covers the URL-backed views has to be applied here too — including for
+ * sandboxes persisted before the lock existed.
+ */
+export const lockedSandboxFiltersAtom = atom(
+  (get) => withForestryLock(get(sandboxFiltersAtom)),
+  (_get, set, next: FilterQueryParam[]) => set(sandboxFiltersAtom, next),
+);
 export const sandboxBreakdownAtom = atom<string | null>(null);
 export const sandboxIndicatorAtom = atom<string | null>(null);
 export const sandboxVisualizationAtom = atom<WidgetVisualizationsType | null>(

--- a/client/src/containers/sidebar/survey-analysis-sidebar/user-sandbox-sidebar/index.tsx
+++ b/client/src/containers/sidebar/survey-analysis-sidebar/user-sandbox-sidebar/index.tsx
@@ -19,8 +19,8 @@ import ClearFiltersButton from "@/containers/sidebar/filter-settings/clear-filte
 import { SURVEY_ANALYSIS_DEFAULT_FILTERS } from "@/containers/sidebar/filter-settings/constants";
 import IndicatorSelector from "@/containers/sidebar/indicator-seletor";
 import {
+  lockedSandboxFiltersAtom,
   sandboxBreakdownAtom,
-  sandboxFiltersAtom,
   sandboxIndicatorAtom,
   sandboxVisualizationAtom,
 } from "@/containers/sidebar/store";
@@ -34,7 +34,7 @@ import {
 } from "@/components/ui/accordion";
 
 const UserSandboxSidebar: FC = () => {
-  const [filters, setFilters] = useAtom(sandboxFiltersAtom);
+  const [filters, setFilters] = useAtom(lockedSandboxFiltersAtom);
   const [breakdown, setBreakdown] = useAtom(sandboxBreakdownAtom);
   const [indicator, setIndicator] = useAtom(sandboxIndicatorAtom);
   const [visualization, setVisualization] = useAtom(sandboxVisualizationAtom);

--- a/client/src/hooks/use-filters.ts
+++ b/client/src/hooks/use-filters.ts
@@ -11,8 +11,11 @@ import qs from "qs";
 
 import {
   ADD_FILTER_MODE,
+  AUTOMATED_DATA_SOURCE_VALUE,
   DATA_SOURCE_FILTER_NAME,
   DEFAULT_DATA_SOURCE_VALUES,
+  FORESTRY_SECTOR_VALUE,
+  SECTOR_FILTER_NAME,
 } from "@/lib/constants";
 import { addFilterQueryParam, removeFilterQueryParamValue } from "@/lib/utils";
 
@@ -35,8 +38,27 @@ const PRESERVED_FILTER_NAMES = [
 export const isPreservedFilter = (name: string) =>
   PRESERVED_FILTER_NAMES.includes(name);
 
-export const hasClearableFilters = (filters: FilterQueryParam[]) =>
-  filters.some((filter) => !isPreservedFilter(filter.name));
+/**
+ * Automated website analysis only covers forestry organisations. Any data source
+ * including it — the comparison mode included, or the two series would be scoped
+ * differently and read as a finding — pins the sector to forestry.
+ */
+export const isSectorLocked = (filters: FilterQueryParam[]) =>
+  filters.some(
+    (filter) =>
+      filter.name === DATA_SOURCE_FILTER_NAME &&
+      filter.values.includes(AUTOMATED_DATA_SOURCE_VALUE),
+  );
+
+export const hasClearableFilters = (filters: FilterQueryParam[]) => {
+  const sectorLocked = isSectorLocked(filters);
+
+  return filters.some(
+    (filter) =>
+      !isPreservedFilter(filter.name) &&
+      !(sectorLocked && filter.name === SECTOR_FILTER_NAME),
+  );
+};
 
 /**
  * Survey analysis always sends an explicit data source; absence of the filter
@@ -61,6 +83,24 @@ export function withDataSourceDefault(
   ];
 }
 
+export function withForestryLock(
+  filters: FilterQueryParam[],
+): FilterQueryParam[] {
+  if (!isSectorLocked(filters)) return filters;
+
+  const locked: FilterQueryParam = {
+    name: SECTOR_FILTER_NAME,
+    operator: "=",
+    values: [FORESTRY_SECTOR_VALUE],
+  };
+
+  return filters.some((filter) => filter.name === SECTOR_FILTER_NAME)
+    ? filters.map((filter) =>
+        filter.name === SECTOR_FILTER_NAME ? locked : filter,
+      )
+    : [...filters, locked];
+}
+
 type ParsedFilterObject = {
   [K in keyof FilterQueryParam]: K extends "values"
     ? string | string[]
@@ -73,7 +113,9 @@ function useFilters() {
   const filters = useMemo(() => {
     const isSurveyAnalysis = SURVEY_ANALYSIS_PATHNAME.test(pathname);
     const applyDefaults = (parsed: FilterQueryParam[]) =>
-      isSurveyAnalysis ? withDataSourceDefault(parsed) : parsed;
+      isSurveyAnalysis
+        ? withForestryLock(withDataSourceDefault(parsed))
+        : parsed;
 
     if (!filtersQuery)
       return PROJECTIONS_PATHNAME.test(pathname)

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -80,6 +80,16 @@ export const DATA_SOURCE_OPTIONS: { label: string; values: string[] }[] = [
 
 export const DEFAULT_DATA_SOURCE_VALUES = ["survey"];
 
+export const AUTOMATED_DATA_SOURCE_VALUE = "automated";
+
+/**
+ * Automated website analysis only covers forestry organisations, so any data
+ * source including it scopes results to that sector. The sidebar calls `sector`
+ * "operation areas" when nothing is selected; the page filter name is `sector`.
+ */
+export const SECTOR_FILTER_NAME = "sector";
+export const FORESTRY_SECTOR_VALUE = "Forestry";
+
 /**
  * Comparison series order. The chart fills the first source solid and hatches the
  * rest, so it and the sidebar legend that explains it both sort by this — pinning

--- a/client/tests/filter-settings/clear-filters-button.test.tsx
+++ b/client/tests/filter-settings/clear-filters-button.test.tsx
@@ -42,6 +42,14 @@ describe("ClearFiltersButton", () => {
     expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
   });
 
+  it("stays hidden when the sector is locked by an automated data source", () => {
+    renderWithQuery(
+      "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=automated&filters[1][name]=sector&filters[1][operator]==&filters[1][values][0]=Forestry",
+    );
+
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+  });
+
   it("appears when a clearable filter sits alongside the data source", () => {
     renderWithQuery(
       "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=survey&filters[1][name]=sector&filters[1][operator]==&filters[1][values][0]=Retail",

--- a/client/tests/filter-settings/locked-sector-filter.test.tsx
+++ b/client/tests/filter-settings/locked-sector-filter.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import FilterPopup from "@/containers/sidebar/filter-settings/filter-popup";
+import type { FilterQueryParam } from "@/hooks/use-filters";
+
+describe("Sector filter locked to Forestry", () => {
+  const onRemoveFilterValue = vi.fn();
+
+  const renderSectorRow = (dataSource: string[], sector: string) => {
+    const filterQueryParams: FilterQueryParam[] = [
+      { name: "data-source", operator: "=", values: dataSource },
+      { name: "sector", operator: "=", values: [sector] },
+    ];
+
+    return render(
+      <FilterPopup
+        name="sector"
+        label={{ selected: "Sector", unSelected: "All operation areas" }}
+        filters={[
+          { name: "sector", label: "Sector", values: ["Agriculture", "Forestry"] },
+        ]}
+        filterQueryParams={filterQueryParams}
+        onAddFilter={vi.fn()}
+        onRemoveFilterValue={onRemoveFilterValue}
+      />,
+    );
+  };
+
+  it("cannot be opened or removed while the data source includes automated", () => {
+    const { container } = renderSectorRow(["automated"], "Forestry");
+    const trigger = screen.getByRole("button", { name: /Sector/ });
+
+    expect(trigger).toHaveTextContent("Forestry");
+    expect(trigger).toHaveAttribute("aria-disabled", "true");
+    expect(trigger).toHaveAccessibleDescription(/forestry organisations only/i);
+    expect(container.querySelector("svg")).toBeNull();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("stays editable for survey-only data", () => {
+    const { container } = renderSectorRow(["survey"], "Agriculture");
+    const trigger = screen.getByRole("button", { name: /Sector/ });
+
+    expect(trigger).not.toHaveAttribute("aria-disabled");
+    expect(container.querySelector("svg")).not.toBeNull();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/client/tests/hooks/useFilters.test.ts
+++ b/client/tests/hooks/useFilters.test.ts
@@ -209,9 +209,11 @@ describe("useFilters", () => {
 
       const { result } = renderHook(() => useFilters());
 
-      expect(result.current.filters).toEqual([
-        { name: "data-source", operator: "=", values: ["survey", "automated"] },
-      ]);
+      expect(result.current.filters).toContainEqual({
+        name: "data-source",
+        operator: "=",
+        values: ["survey", "automated"],
+      });
     });
 
     it("never applies the data source default on projections", () => {
@@ -243,6 +245,71 @@ describe("useFilters", () => {
       expect(mockSetFiltersQuery).toHaveBeenCalledWith(
         "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=automated",
       );
+    });
+  });
+
+  describe("forestry lock", () => {
+    const FORESTRY_SECTOR = {
+      name: "sector",
+      operator: "=",
+      values: ["Forestry"],
+    };
+
+    const mockSetFiltersQuery = vi.fn();
+
+    beforeEach(() => {
+      vi.mocked(usePathname).mockReturnValue("/survey-analysis");
+    });
+
+    it("overwrites a conflicting sector when the data source is automated", () => {
+      vi.mocked(useQueryState).mockReturnValue([
+        "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=automated&filters[1][name]=sector&filters[1][operator]==&filters[1][values][0]=Agriculture",
+        mockSetFiltersQuery,
+      ]);
+
+      const { result } = renderHook(() => useFilters());
+
+      expect(result.current.filters).toEqual([
+        { name: "data-source", operator: "=", values: ["automated"] },
+        FORESTRY_SECTOR,
+      ]);
+    });
+
+    it("locks the sector in comparison mode so both sources share a population", () => {
+      vi.mocked(useQueryState).mockReturnValue([
+        "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=survey&filters[0][values][1]=automated&filters[1][name]=sector&filters[1][operator]==&filters[1][values][0]=Agriculture",
+        mockSetFiltersQuery,
+      ]);
+
+      const { result } = renderHook(() => useFilters());
+
+      expect(result.current.filters).toContainEqual(FORESTRY_SECTOR);
+    });
+
+    it("adds the locked sector when the query has none", () => {
+      vi.mocked(useQueryState).mockReturnValue([
+        "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=automated",
+        mockSetFiltersQuery,
+      ]);
+
+      const { result } = renderHook(() => useFilters());
+
+      expect(result.current.filters).toContainEqual(FORESTRY_SECTOR);
+    });
+
+    it("leaves the sector alone for survey-only data", () => {
+      vi.mocked(useQueryState).mockReturnValue([
+        "filters[0][name]=data-source&filters[0][operator]==&filters[0][values][0]=survey&filters[1][name]=sector&filters[1][operator]==&filters[1][values][0]=Agriculture",
+        mockSetFiltersQuery,
+      ]);
+
+      const { result } = renderHook(() => useFilters());
+
+      expect(result.current.filters).toContainEqual({
+        name: "sector",
+        operator: "=",
+        values: ["Agriculture"],
+      });
     });
   });
 });


### PR DESCRIPTION
## Lock the sector to Forestry when the data source includes Automated

### Overview

Automated website analysis covers forestry organisations only, but nothing enforced that. Selecting **Automated web data** alongside `sector = Agriculture` returned rows labelled as automated web data that were not forestry. In **Survey and Automated** the failure was worse: a forestry-only automated series was charted against an all-sector survey series, so the gap read as a finding rather than as a difference in scope.

Whenever the selected data source includes `automated` — comparison mode included — `sector` is now pinned to `Forestry` and the row is read-only.

**Where the rule lives.** `isSectorLocked` / `withForestryLock` in `client/src/hooks/use-filters.ts`, composed into the existing derivation next to `withDataSourceDefault`. Applying it at read time rather than in the radio's `onChange` means a shared URL, a hand-edited `?q=`, or a sandbox saved before this change is corrected on render — not only when someone clicks the radio.

**Saved sandboxes needed their own path.** They never pass through `useFilters`; they read `sandboxFiltersAtom` directly in five places, including the widget query in `containers/sandbox/user-sandbox/index.tsx` and the save mutation. A derived `lockedSandboxFiltersAtom` normalises on read and passes writes through, so the sidebar chip and the chart beside it can't disagree.

**Locked row.** Keeps its value visible — hiding it would reintroduce the same invisible-scope problem — loses the chip's remove control, and won't open. It uses `aria-disabled` plus a described reason rather than the `disabled` attribute, which would drop it from the tab order and hide the explanation from screen readers.

**One knock-on fix.** `hasClearableFilters` counted the locked sector as clearable, so with only the data source and the locked sector present the Clear-all button rendered and did visibly nothing.

### Scope — please read before approving

This is **client-side only**. It is a scope the UI refuses to misrepresent, not an invariant:

- The seed is untouched. `data-source-manager.ts:258-291` still clones the first 100 survey respondents verbatim as `automated`, sector answers included — so automated rows genuinely include Agriculture and Both.
- No API enforcement. `sql-adapter.ts` is untouched; a request that bypasses the client still returns non-forestry automated rows.

The **Data sources** dialog copy is unchanged. Its claim that the comparison "is available only for forestry data" was aspirational before this PR; the lock is what starts making it hold in the UI. Two gaps remain in that sentence — there is still no theme allowlist behind "and selected themes", and the seeded rows aren't really forestry-only — but both are about the data and the backend, not this change.

The claim becomes true below the client when the real VTT feed replaces the seeded stand-in.

### Testing instructions

Requires `SEED_AUTOMATED_MOCK_DATA` on — already the default in `api/config/development.json`, otherwise the data-source filter is stripped from `GET /filters`.

`docker-compose up`, then `/survey-analysis`:

1. Set **Sector** to Agriculture. Switch **Data is** to *Automated web data* → the chip flips to Forestry, loses its X, and the row no longer opens. Widget counts drop.
2. Tab to the sector row → it still receives focus and the reason is announced (checked with VoiceOver).
3. Switch to *Survey and Automated* → sector stays locked; both comparison series are forestry-scoped.
4. Switch back to *Survey responses* → sector shows Forestry and is editable again. The previous Agriculture value is **not** restored — deliberate, there's no stash.
5. **Clear all** is hidden when only the data source and locked sector remain; it reappears once another filter is added.
6. Repeat below the `md` breakpoint via the bottom-bar filters sheet, including Apply.
7. Open a saved sandbox whose stored filters contain `automated` plus a non-Forestry sector → it normalises on load and the widget re-queries with Forestry.

**Automated:** `cd client && pnpm test` — 167 pass. Seven tests cover this; I disabled `isSectorLocked` and confirmed five of them fail without it (the two that still pass are survey-only control cases, which should pass either way).

**Note on tooling:** `cd client && pnpm lint` fails on `dev` too — ESLint 10.2.0 is installed against an `.eslintrc` config and `next lint` passes removed options. `pnpm check-types` is clean apart from one pre-existing error in generated `.next/types/app/layout.ts`. Both verified against a clean tree; neither is caused by this branch.

### Feature relevant tickets

None — follow-up to the source-comparison work in #348.
