### PR TITLE
fix(projections): send dataFilters on CSV export requests

### DIFF
--- a/api/test/e2e/projections/export-projection.spec.ts
+++ b/api/test/e2e/projections/export-projection.spec.ts
@@ -193,5 +193,49 @@ describe('Projections CSV export', () => {
         ['unit', 'year', 'value'].sort(),
       );
     });
+
+    it('applies dataFilters to the exported data', async () => {
+      const listRes = await testManager
+        .request()
+        .get(c.getProjectionsWidgets.path);
+      const widgetId = (listRes.body.data as Array<{ id: number }>)[0].id;
+
+      const exportForCategory = (category: string) =>
+        testManager
+          .request()
+          .get(
+            `/projections/widgets/${widgetId}/export?dataFilters[0][name]=category&dataFilters[0][operator]==&dataFilters[0][values][0]=${category}`,
+          );
+
+      const [forestry, agriculture, unfiltered] = await Promise.all([
+        exportForCategory('Forestry'),
+        exportForCategory('Agriculture'),
+        testManager.request().get(`/projections/widgets/${widgetId}/export`),
+      ]);
+
+      expect(forestry.status).toBe(200);
+      expect(agriculture.status).toBe(200);
+      expect(unfiltered.status).toBe(200);
+
+      // Aggregates are float8 sums, so identical requests differ in the last
+      // decimals. Compare magnitudes, not CSV text.
+      const firstYearValue = (csv: string): number => {
+        const rows = parse(csv, { columns: true }) as Array<{ value: string }>;
+        return Number(rows[0].value);
+      };
+      const relativeDiff = (a: number, b: number): number =>
+        Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b));
+
+      const forestryValue = firstYearValue(forestry.text);
+      const agricultureValue = firstYearValue(agriculture.text);
+      const unfilteredValue = firstYearValue(unfiltered.text);
+
+      expect(forestryValue).toBeGreaterThan(0);
+      expect(agricultureValue).toBeGreaterThan(0);
+      expect(relativeDiff(forestryValue, agricultureValue)).toBeGreaterThan(
+        0.01,
+      );
+      expect(relativeDiff(forestryValue, unfilteredValue)).toBeGreaterThan(0.01);
+    });
   });
 });

--- a/client/src/containers/widget/projections/index.tsx
+++ b/client/src/containers/widget/projections/index.tsx
@@ -5,11 +5,11 @@ import { useEffect, useMemo, useState } from "react";
 import { ProjectionVisualizationsType } from "@shared/dto/projections/projection-visualizations.constants";
 import { ProjectionWidgetData } from "@shared/dto/projections/projection-widget.entity";
 import { useAtom } from "jotai";
-import qs from "qs";
 
-import { env } from "@/env";
 import { cn } from "@/lib/utils";
 import useFilters from "@/hooks/use-filters";
+
+import { buildProjectionWidgetDownloadUrl } from "@/utils/download-url";
 
 import { focusedWidgetAtom } from "@/containers/explore/store";
 import NoData from "@/containers/no-data";
@@ -66,10 +66,7 @@ export default function Widget({
   const [showOverlay, setShowOverlay] = useAtom(showOverlayAtom);
   const [focusedWidget, setFocusedWidget] = useAtom(focusedWidgetAtom);
   const { filters } = useFilters();
-  const downloadUrl = `${env.NEXT_PUBLIC_API_URL}/projections/widgets/${id}/export?${qs.stringify(
-    { filters },
-    { encode: false },
-  )}`;
+  const downloadUrl = buildProjectionWidgetDownloadUrl(id, filters);
   const highlightWidget = showOverlay && indicator === focusedWidget;
   const menuComponent = (
     <WidgetMenu

--- a/client/src/utils/download-url.ts
+++ b/client/src/utils/download-url.ts
@@ -15,13 +15,23 @@ export function buildWidgetDownloadUrl(
   )}`;
 }
 
+export function buildProjectionWidgetDownloadUrl(
+  id: number,
+  dataFilters: FilterQueryParam[],
+): string {
+  return `${env.NEXT_PUBLIC_API_URL}/projections/widgets/${id}/export?${qs.stringify(
+    { dataFilters },
+    { encode: false },
+  )}`;
+}
+
 export function buildProjectionDownloadUrl(
-  filters: FilterQueryParam[],
+  dataFilters: FilterQueryParam[],
   settings: Record<string, unknown> | null,
   othersAggregation: string,
 ): string {
   return `${env.NEXT_PUBLIC_API_URL}/projections/custom-widget/export?${qs.stringify(
-    { filters, settings, othersAggregation },
+    { dataFilters, settings, othersAggregation },
     { encode: false },
   )}`;
 }


### PR DESCRIPTION
## Context

QC on STAGING reported that the projections CSV download does not match the UI: 2040 penetration reads **23.77%** on screen and **33.15%** in the file, for both agriculture and forestry. They also observed the downloaded CSV is **identical regardless of user selection**.

**This is a frontend bug.**

## Root cause

The projections API distinguishes two filter params (`shared/schemas/search-filters.schema.ts`):

- `filters` — narrows the *widget entities*
- `dataFilters` — narrows the *nested projection data*

The chart queries sent `dataFilters`. Both CSV export URLs sent `filters`.

| Path | Client sent | API reads |
|---|---|---|
| `getProjectionsWidgets` | `dataFilters` ✅ | `dataFilters` |
| `getCustomProjection` | `dataFilters` ✅ | `dataFilters` |
| `/projections/widgets/:id/export` | `filters` ❌ | `dataFilters` |
| `/projections/custom-widget/export` | `filters` ❌ | `dataFilters` |

`SearchFiltersSchema` declares **both** keys as optional, so `filters` passed validation and was then silently discarded. `dataFilters` fell back to `[]`, leaving only the server-injected `type` predicate — so every download aggregated all scenarios, categories and countries. Hence "always the same file".

Penetration diverges most because `%` is aggregated with `AVG` while other units use `SUM` (`postgres-projection-data.repository.ts`). Averaging the unfiltered universe yields an unrelated number rather than a proportionally scaled one.

Confirmed empirically against the seeded database: `filters=Agriculture` returned `8,287,903,511`, which is exactly `dataFilters=Forestry` (`4,370,681,335`) + `dataFilters=Agriculture` (`3,917,222,176`) — the full dataset.

Survey-analysis exports were never affected; they send `filters` and the widgets service reads `filters`.

## Changes

- `client/src/utils/download-url.ts` — `buildProjectionDownloadUrl` now emits `dataFilters`; added `buildProjectionWidgetDownloadUrl` so both projection exports share one place that knows the param name.
- `client/src/containers/widget/projections/index.tsx` — replaced the inline URL construction with the shared builder; dropped the now-unused `qs`/`env` imports.
- `api/test/e2e/projections/export-projection.spec.ts` — regression test asserting the export actually consumes `dataFilters`. The suite previously had **zero** filter assertions, which is why CI never caught this.

## Note on the test

The first version of the regression test compared raw CSV text with `not.toEqual` and **passed even with the bug reintroduced**. Postgres `SUM` over `float8` is order-nondeterministic — two identical unfiltered requests returned `...628092` and `...628099`, so the assertion was satisfied by float jitter rather than by filtering.

The test now parses values and compares relative magnitudes. Re-run with the buggy `filters` param it yields a relative difference of `1.7e-15` against a required `0.01`, so it fails as intended.

## Verification

- `export-projection` e2e: 9/9 passed; confirmed failing when the bug is reintroduced.
- API `lint` and `check-types`: clean.
- Client tests: 167/167 passed.

Manual check against a running stack:

1. Open `/projections`, select **Operation area = Forestry** and a scenario.
2. Read the 2040 penetration value from the chart tooltip.
3. Download the CSV — the `%`/2040 row now matches (the CSV is unrounded).
4. Switch to **Agriculture** and download again — the file now differs.

## Pre-existing failures (not from this PR)

Both reproduce identically on a clean `dev` tree:

- Client `check-types` errors on a stale `.next/types/app/layout.ts` artifact (`isMobileDevice`).
- Client `lint` fails because `next lint` passes removed options to the current ESLint.

## Out of scope

Found while tracing, deliberately excluded — worth filing separately:

- The CSV writes a row per **unit** while the UI shows one selected unit; `selectedUnit` is local state and never sent.
- `findSimpleProjectionCustomWidgetData` and the bubble-chart queries use unconditional `SUM(value)` with no `%` branch, so custom-chart penetration can exceed 100%. Affects chart and CSV identically, so it is not the QC symptom.
- `serializeWidgetDataToCsv` has no `bySource` branch, so survey CSVs omit the per-source split when comparing data sources.
- `CLAUDE.md` documents `--testPathPattern`, which this Jest version rejects; it is now `--testPathPatterns`.